### PR TITLE
fix: Add fallback logic for finding appropriate welcome workspace directory if no documents directory is set

### DIFF
--- a/backend/src/commands/workspaces.rs
+++ b/backend/src/commands/workspaces.rs
@@ -18,7 +18,12 @@ pub async fn copy_welcome_workspace(app: AppHandle) -> Result<String, String> {
         .resolve("resources/welcome", BaseDirectory::Resource)
         .map_err(|e| e.to_string())?;
 
-    let documents_path = app.path().document_dir().map_err(|e| e.to_string())?;
+    let documents_path = app
+        .path()
+        .document_dir()
+        .or_else(|_| app.path().home_dir()) // possible for a linux system to have no document directory
+        .or_else(|_| app.path().app_config_dir()) // can't imagine we'd ever have to fallback to here, but we know the dir works
+        .map_err(|_| "Failed to locate a suitable directory for welcome workspace")?;
 
     let mut target_path = documents_path
         .join("Atuin Runbooks")


### PR DESCRIPTION
This PR falls back to the home directory, and if that (somehow) fails, the app config directory (where the Tauri SQL plugin writes the database files) for the welcome workspace if no documents directory is set.

Thanks to @ComputerDruid for helping us track this down.

See also https://codeberg.org/dirs/dirs-sys-rs/issues/10
Ref https://discord.com/channels/954121165239115808/1422660189387231232