### PR TITLE
fix: prevent re-running terminal on visibility change

### DIFF
--- a/src/lib/blocks/terminal/component.tsx
+++ b/src/lib/blocks/terminal/component.tsx
@@ -94,11 +94,7 @@ export const RunBlock = ({
     return colorMode === "dark" ? darkModeEditorTheme : lightModeEditorTheme;
   }, [colorMode, lightModeEditorTheme, darkModeEditorTheme]);
 
-  // This ensures that the first time we run a block, it executes the code. But subsequent mounts of an already-existing pty
-  // don't run the code again.
-  // We have to write to the pty from the terminal component atm, because it needs to be listening for data from the pty before
-  // we write to it.
-  const [firstOpen, setFirstOpen] = useState<boolean>(false);
+
 
   const currentRunbookId = useCurrentRunbookId();
 
@@ -265,7 +261,6 @@ export const RunBlock = ({
       try {
         let p = await openPty();
         setIsLoading(false);
-        setFirstOpen(true);
 
         if (onRun) onRun(p);
       } catch (error) {
@@ -473,7 +468,6 @@ export const RunBlock = ({
                 block_id={terminal.id}
                 pty={pty.pid}
                 script={terminal.code}
-                runScript={firstOpen}
                 setCommandRunning={setCommandRunning}
                 setExitCode={setExitCode}
                 setCommandDuration={setCommandDuration}
@@ -529,7 +523,6 @@ export const RunBlock = ({
                 block_id={terminal.id}
                 pty={pty.pid}
                 script={terminal.code}
-                runScript={false}
                 setCommandRunning={setCommandRunning}
                 setExitCode={setExitCode}
                 setCommandDuration={setCommandDuration}

--- a/src/lib/blocks/terminal/components/terminal.tsx
+++ b/src/lib/blocks/terminal/components/terminal.tsx
@@ -32,7 +32,6 @@ const TerminalComponent = ({
   block_id,
   pty,
   script,
-  runScript,
   setCommandRunning,
   setExitCode,
   setCommandDuration,
@@ -92,12 +91,14 @@ const TerminalComponent = ({
 
       window.addEventListener("resize", windowResize);
 
-      if (runScript) {
+      // Run script only if it hasn't been run before for this PTY
+      if (!terminalData.hasRunInitialScript && script && terminalData.terminal.element) {
         let isWindows = platform() == "windows";
         let cmdEnd = isWindows ? "\r\n" : "\n";
         let val = !script.endsWith("\n") ? script + cmdEnd : script;
 
         terminalData.write(block_id, val, editor.document, currentRunbookId);
+        terminalData.hasRunInitialScript = true;
       }
     }
 

--- a/src/state/store/pty_state.ts
+++ b/src/state/store/pty_state.ts
@@ -23,6 +23,7 @@ export class TerminalData extends Emittery {
   unlisten: UnlistenFn | null;
 
   startTime: number | null;
+  hasRunInitialScript: boolean;
 
   constructor(pty: string, terminal: Terminal, fit: FitAddon) {
     super();
@@ -32,6 +33,7 @@ export class TerminalData extends Emittery {
     this.pty = pty;
     this.startTime = null;
     this.unlisten = null;
+    this.hasRunInitialScript = false;
 
     this.disposeResize = this.terminal.onResize((e) => this.onResize(e));
     this.disposeOnData = this.terminal.onData((e) => this.onData(e));

--- a/src/state/store/pty_state.ts
+++ b/src/state/store/pty_state.ts
@@ -23,6 +23,12 @@ export class TerminalData extends Emittery {
   unlisten: UnlistenFn | null;
 
   startTime: number | null;
+  /**
+   * Flag to prevent the initial command from being re-run across component remounts.
+   * This is set to true after the initial script is run, and should only be reset
+   * when a new PTY/TerminalData instance is created (i.e., when a new terminal session starts).
+   * Ensures that the initial command is not executed multiple times for the same session.
+   */
   hasRunInitialScript: boolean;
 
   constructor(pty: string, terminal: Terminal, fit: FitAddon) {


### PR DESCRIPTION
Previously, toggling terminal visibility would cause the command to run over-and-over. Fix this by storing a flag inside terminaldata, which is persisted regardless of component mount status.