### PR TITLE
fix: panic on max count expect

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -255,10 +255,12 @@ async fn history_calendar(
     // probs don't want to iterate _this_ many times, but it's only the last year. so 365
     // iterations at max. should be quick.
 
+    // Handle case where calendar is empty (can happen on Linux with XDG dir issues)
+    let default_entry = (String::new(), 0);
     let max = calendar
         .iter()
         .max_by_key(|d| d.1)
-        .expect("Can't find max count");
+        .unwrap_or(&default_entry);
 
     let ret = calendar
         .iter()


### PR DESCRIPTION
A user reported this issue on setup

```
thread 'tokio-runtime-worker' panicked at src/main.rs:260:10:
Can't find max count
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Not 100% sure if this is causing setup problems, but it should be fixed regardless. 

Ref: https://discord.com/channels/954121165239115808/1422660189387231232/1422883122768515132