### PR TITLE
chore: remove ssh agent from CI

### DIFF
--- a/.github/workflows/ts-tests.yaml
+++ b/.github/workflows/ts-tests.yaml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.TS_CLONE_DEPLOY_KEY }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tsc-check.yaml
+++ b/.github/workflows/tsc-check.yaml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.TS_CLONE_DEPLOY_KEY }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Packages are now public, so we no longer need to add a key