### PR TITLE
chore: adjust wording on dropdown for clarity

### DIFF
--- a/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
+++ b/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
@@ -476,7 +476,7 @@ const Dropdown = ({
 
         <div className="flex-1">
           <Input
-            placeholder="Output variable name"
+            placeholder="Template variable name"
             value={name}
             onChange={handleKeyChange}
             style={{ fontFamily: "monospace" }}
@@ -624,10 +624,7 @@ export default createReactBlockSpec(
     toExternalHTML: ({ block }) => {
       const props = block.props;
 
-      let propsToExport = [
-        "name",
-        "optionsType",
-      ];
+      let propsToExport = ["name", "optionsType"];
 
       if (props.optionsType === "fixed") propsToExport.push("fixedOptions");
       if (props.optionsType === "variable") propsToExport.push("variableOptions");
@@ -635,11 +632,11 @@ export default createReactBlockSpec(
 
       let propMatter = exportPropMatter("dropdown", props, propsToExport);
 
-        return (
-          <div>
-            <pre lang="dropdown">{propMatter}</pre>
-          </div>
-        );
+      return (
+        <div>
+          <pre lang="dropdown">{propMatter}</pre>
+        </div>
+      );
     },
     // @ts-ignore
     render: ({ block, editor }) => {


### PR DESCRIPTION
Should make it clearer that the dropdown defines template variables, not env vars. Ref #64 