### PR TITLE
chore: add intel macos build

### DIFF
--- a/.github/workflows/tauri-release.yaml
+++ b/.github/workflows/tauri-release.yaml
@@ -136,7 +136,7 @@ jobs:
         with:
           args: ${{ matrix.args }}
 
-      - name: Rename Linux files and upload to GitHub release
+      - name: Rename platform-specific files and upload to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -147,7 +147,15 @@ jobs:
           paths_str=$(echo "${{ steps.tauri-action.outputs.artifactPaths }}" | sed 's/^\[//;s/\]$//')
           IFS=',' read -ra paths <<< "$paths_str"
 
-          # Rename .deb and .rpm files to remove spaces and upload to GitHub release
+          # Determine platform suffix based on matrix args
+          platform_suffix=""
+          if [[ "${{ matrix.args }}" == *"aarch64-apple-darwin"* ]]; then
+            platform_suffix="-aarch64"
+          elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
+            platform_suffix="-x86_64"
+          fi
+
+          # Rename files and upload to GitHub release
           for file in "${paths[@]}"; do
             echo "Checking file: $file"
             if [[ "$file" == *.deb ]] || [[ "$file" == *.rpm ]]; then
@@ -166,6 +174,27 @@ jobs:
                 gh release upload "${{ github.ref_name }}" "$new_path" --clobber
               else
                 echo "No rename needed for: $filename"
+                gh release upload "${{ github.ref_name }}" "$file" --clobber
+              fi
+            elif [[ "$file" == *.app.tar.gz ]] || [[ "$file" == *.app.tar.gz.sig ]]; then
+              # Rename macOS app bundles to include platform suffix
+              if [[ -n "$platform_suffix" ]]; then
+                dir=$(dirname "$file")
+                filename=$(basename "$file")
+                
+                echo "Processing macOS file: $filename"
+                if [[ "$file" == *.app.tar.gz.sig ]]; then
+                  new_filename=$(echo "$filename" | sed "s/\.app\.tar\.gz\.sig$/${platform_suffix}.app.tar.gz.sig/")
+                else
+                  new_filename=$(echo "$filename" | sed "s/\.app\.tar\.gz$/${platform_suffix}.app.tar.gz/")
+                fi
+                
+                new_path="$dir/$new_filename"
+                echo "Renaming: $file -> $new_path"
+                mv "$file" "$new_path"
+                gh release upload "${{ github.ref_name }}" "$new_path" --clobber
+              else
+                echo "No platform suffix for: $filename"
                 gh release upload "${{ github.ref_name }}" "$file" --clobber
               fi
             elif [[ "$file" == *.app ]]; then

--- a/.github/workflows/tauri-release.yaml
+++ b/.github/workflows/tauri-release.yaml
@@ -176,8 +176,8 @@ jobs:
                 echo "No rename needed for: $filename"
                 gh release upload "${{ github.ref_name }}" "$file" --clobber
               fi
-            elif [[ "$file" == *.app.tar.gz ]] || [[ "$file" == *.app.tar.gz.sig ]]; then
-              # Rename macOS app bundles to include platform suffix
+            elif [[ "$file" == *.app.tar.gz ]] || [[ "$file" == *.app.tar.gz.sig ]] || [[ "$file" == *.dmg ]]; then
+              # Rename macOS files to include platform suffix
               if [[ -n "$platform_suffix" ]]; then
                 dir=$(dirname "$file")
                 filename=$(basename "$file")
@@ -185,8 +185,10 @@ jobs:
                 echo "Processing macOS file: $filename"
                 if [[ "$file" == *.app.tar.gz.sig ]]; then
                   new_filename=$(echo "$filename" | sed "s/\.app\.tar\.gz\.sig$/${platform_suffix}.app.tar.gz.sig/")
-                else
+                elif [[ "$file" == *.app.tar.gz ]]; then
                   new_filename=$(echo "$filename" | sed "s/\.app\.tar\.gz$/${platform_suffix}.app.tar.gz/")
+                elif [[ "$file" == *.dmg ]]; then
+                  new_filename=$(echo "$filename" | sed "s/\.dmg$/${platform_suffix}.dmg/")
                 fi
                 
                 new_path="$dir/$new_filename"
@@ -194,7 +196,6 @@ jobs:
                 mv "$file" "$new_path"
                 gh release upload "${{ github.ref_name }}" "$new_path" --clobber
               else
-                echo "No platform suffix for: $filename"
                 gh release upload "${{ github.ref_name }}" "$file" --clobber
               fi
             elif [[ "$file" == *.app ]]; then

--- a/.github/workflows/tauri-release.yaml
+++ b/.github/workflows/tauri-release.yaml
@@ -77,6 +77,8 @@ jobs:
         include:
           - platform: "macos-latest" # for Arm based macs (M1 and above).
             args: "--target aarch64-apple-darwin"
+          - platform: "macos-15-intel"
+            args: "--target x86_64-apple-darwin"
           - platform: "depot-ubuntu-22.04-4"
             args: ""
 
@@ -108,7 +110,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ (matrix.platform == 'macos-latest') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ (matrix.platform == 'macos-latest' || matrix.platform == 'macos-15-intel') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
Closes #45 

@BinaryMuse - afaik this should also build the `latest.json` correctly, but we will probably need to ensure the release editing runbook can properly merge all the platforms + signatures?

For channels, we can just have `latest-nightly.json` or similar. I don't think we can release for intel on that, because the runners are $$$$$