### PR TITLE
feat(runbooks): Add collapsible code blocks

### DIFF
--- a/src/lib/blocks/common/SQL.tsx
+++ b/src/lib/blocks/common/SQL.tsx
@@ -348,20 +348,25 @@ const SQL = ({
               onPlay={handlePlay}
               cancellable={false}
             />
-            <CodeMirror
-              placeholder={"Write your query here..."}
-              className={cn("!pt-0 max-w-full border border-gray-300 rounded flex-grow", {
-                "h-8 overflow-hidden": collapseQuery,
-              })}
-              basicSetup={true}
-              extensions={[getSqlExtension(), ...extensions]}
-              value={codeMirrorValue.value}
-              onChange={codeMirrorValue.onChange}
-              editable={isEditable}
-              theme={themeObj}
-              maxHeight="100vh"
-              onFocus={onCodeMirrorFocus}
-            />
+            <div className={cn("flex-grow relative transition-all duration-300 ease-in-out", {
+              "max-h-10 overflow-hidden": collapseQuery,
+            })}>
+              <CodeMirror
+                placeholder={"Write your query here..."}
+                className="!pt-0 max-w-full border border-gray-300 rounded"
+                basicSetup={true}
+                extensions={[getSqlExtension(), ...extensions]}
+                value={codeMirrorValue.value}
+                onChange={codeMirrorValue.onChange}
+                editable={isEditable}
+                theme={themeObj}
+                maxHeight="100vh"
+                onFocus={onCodeMirrorFocus}
+              />
+              {collapseQuery && (
+                <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white dark:from-gray-900 to-transparent pointer-events-none" />
+              )}
+            </div>
           </div>
         </>
       }

--- a/src/lib/blocks/terminal/component.tsx
+++ b/src/lib/blocks/terminal/component.tsx
@@ -13,10 +13,10 @@ import { useBlockNoteEditor } from "@blocknote/react";
 import "@xterm/xterm/css/xterm.css";
 import { AtuinState, useStore } from "@/state/store.ts";
 import { addToast, Button, Chip, Spinner, Tooltip } from "@heroui/react";
-import { formatDuration } from "@/lib/utils.ts";
+import { formatDuration, cn } from "@/lib/utils.ts";
 import { usePtyStore } from "@/state/ptyStore.ts";
 import track_event from "@/tracking.ts";
-import { Clock, Eye, EyeOff, Maximize2, Minimize2 } from "lucide-react";
+import { Clock, Eye, EyeOff, Maximize2, Minimize2, ArrowDownToLineIcon, ArrowUpToLineIcon } from "lucide-react";
 import EditableHeading from "@/components/EditableHeading/index.tsx";
 import { templateString } from "@/state/templates.ts";
 import CodeEditor, { TabAutoComplete } from "../common/CodeEditor/CodeEditor.tsx";
@@ -51,6 +51,9 @@ interface RunBlockProps {
   setOutputVisible: (visible: boolean) => void;
   setDependency: (dependency: DependencySpec) => void;
   onCodeMirrorFocus?: () => void;
+  
+  collapseCode: boolean;
+  setCollapseCode: (collapse: boolean) => void;
 
   terminal: TerminalBlock;
 }
@@ -65,6 +68,8 @@ export const RunBlock = ({
   terminal,
   setDependency,
   onCodeMirrorFocus,
+  collapseCode,
+  setCollapseCode,
 }: RunBlockProps) => {
   let editor = useBlockNoteEditor();
   const colorMode = useStore((state) => state.functionalColorMode);
@@ -427,6 +432,14 @@ export const RunBlock = ({
                   {isFullscreen ? <Minimize2 size={20} /> : <Maximize2 size={20} />}
                 </button>
               </Tooltip>
+              <Tooltip content={collapseCode ? "Expand code" : "Collapse code"}>
+                <button
+                  onClick={() => setCollapseCode(!collapseCode)}
+                  className="p-2 hover:bg-default-100 rounded-md"
+                >
+                  {collapseCode ? <ArrowDownToLineIcon size={20} /> : <ArrowUpToLineIcon size={20} />}
+                </button>
+              </Tooltip>
             </div>
           </div>
 
@@ -440,22 +453,29 @@ export const RunBlock = ({
               onRefresh={handleRefresh}
               alwaysStop
             />
-            <CodeEditor
-              id={terminal.id}
-              code={terminal.code}
-              onChange={onChange}
-              isEditable={isEditable}
-              language="bash"
-              theme={theme}
-              onFocus={onCodeMirrorFocus}
-              keyMap={[
-                TabAutoComplete,
-                {
-                  key: "Mod-Enter",
-                  run: handleCmdEnter,
-                },
-              ]}
-            />
+            <div className={cn("min-w-0 flex-1 overflow-x-auto transition-all duration-300 ease-in-out relative", {
+              "max-h-10 overflow-hidden": collapseCode,
+            })}>
+              <CodeEditor
+                id={terminal.id}
+                code={terminal.code}
+                onChange={onChange}
+                isEditable={isEditable}
+                language="bash"
+                theme={theme}
+                onFocus={onCodeMirrorFocus}
+                keyMap={[
+                  TabAutoComplete,
+                  {
+                    key: "Mod-Enter",
+                    run: handleCmdEnter,
+                  },
+                ]}
+              />
+              {collapseCode && (
+                <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white dark:from-gray-900 to-transparent pointer-events-none" />
+              )}
+            </div>
           </div>
         </>
       }

--- a/src/lib/blocks/terminal/schema.ts
+++ b/src/lib/blocks/terminal/schema.ts
@@ -61,6 +61,9 @@ export const TERMINAL_BLOCK_SCHEMA = {
     outputVisible: {
       default: true,
     },
+    collapseCode: {
+      default: false,
+    },
     dependency: { default: "{}" },
   },
   content: "none",

--- a/src/lib/blocks/terminal/spec.tsx
+++ b/src/lib/blocks/terminal/spec.tsx
@@ -47,6 +47,12 @@ export default createReactBlockSpec(
             props: { ...block.props, outputVisible: visible },
           });
         };
+
+        const setCollapseCode = (collapse: boolean) => {
+          editor.updateBlock(block, {
+            props: { ...block.props, collapseCode: collapse },
+          });
+        };
   
         const setDependency = (dependency: DependencySpec) => {
           editor.updateBlock(block, {
@@ -76,6 +82,8 @@ export default createReactBlockSpec(
             terminal={terminal}
             setDependency={setDependency}
             onCodeMirrorFocus={handleCodeMirrorFocus}
+            collapseCode={block.props.collapseCode}
+            setCollapseCode={setCollapseCode}
           />
         );
       },


### PR DESCRIPTION
Add collapse/expand functionality to improve navigation with long scripts:
- Add collapse buttons to Script, Terminal, and Editor blocks

fixes: #72