### PR TITLE
chore: Remove --no-sync option from script/dev

### DIFF
--- a/script/dev
+++ b/script/dev
@@ -6,7 +6,6 @@ show_help() {
     echo ""
     echo "Options:"
     echo "  -p --profile VALUE   Start with the given dev profile"
-    echo "  -s --no-sync         Start with automatic sync disabled"
     echo "  -d --devtools        Start with devtools opened"
     echo "  -h --help            Display this help message and exit"
     echo ""
@@ -14,17 +13,12 @@ show_help() {
 
 # Parse command line arguments
 PROFILE=""
-NO_SYNC=""
 DEVTOOLS=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         -p|--profile)
             PROFILE="$2"
             shift 2
-            ;;
-        -s|--no-sync)
-            NO_SYNC="1"
-            shift
             ;;
         -d|--devtools)
             DEVTOOLS="1"
@@ -71,30 +65,30 @@ EOF
     # Run Tauri with custom config and optional profile
     if [ -n "$PROFILE" ]; then
         if [ -n "$DEVTOOLS" ]; then
-            DEV_PREFIX="$PROFILE" NO_SYNC="$NO_SYNC" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev --config "$CONFIG_FILE"
+            DEV_PREFIX="$PROFILE" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev --config "$CONFIG_FILE"
         else
-            DEV_PREFIX="$PROFILE" NO_SYNC="$NO_SYNC" pnpm run tauri dev --config "$CONFIG_FILE"
+            DEV_PREFIX="$PROFILE" pnpm run tauri dev --config "$CONFIG_FILE"
         fi
     else
         if [ -n "$DEVTOOLS" ]; then
-            NO_SYNC="$NO_SYNC" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev --config "$CONFIG_FILE"
+            DEVTOOLS="$DEVTOOLS" pnpm run tauri dev --config "$CONFIG_FILE"
         else
-            NO_SYNC="$NO_SYNC" pnpm run tauri dev --config "$CONFIG_FILE"
+            pnpm run tauri dev --config "$CONFIG_FILE"
         fi
     fi
 else
     # Run Tauri with default config and optional profile
     if [ -n "$PROFILE" ]; then
         if [ -n "$DEVTOOLS" ]; then
-            DEV_PREFIX="$PROFILE" NO_SYNC="$NO_SYNC" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev
+            DEV_PREFIX="$PROFILE" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev
         else
-            DEV_PREFIX="$PROFILE" NO_SYNC="$NO_SYNC" pnpm run tauri dev
+            DEV_PREFIX="$PROFILE" pnpm run tauri dev
         fi
     else
         if [ -n "$DEVTOOLS" ]; then
-            NO_SYNC="$NO_SYNC" DEVTOOLS="$DEVTOOLS" pnpm run tauri dev
+            DEVTOOLS="$DEVTOOLS" pnpm run tauri dev
         else
-            NO_SYNC="$NO_SYNC" pnpm run tauri dev
+            pnpm run tauri dev
         fi
     fi
 fi


### PR DESCRIPTION
This no longer makes sense as our syncing strategy has changed