### PR TITLE
chore: Use special updater endpoint for edge builds

### DIFF
--- a/.github/workflows/tauri-edge.yaml
+++ b/.github/workflows/tauri-edge.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   NODE_ENV: production
+  APP_CHANNEL: edge
 
 jobs:
   create-release:
@@ -102,6 +103,17 @@ jobs:
 
       - name: install frontend dependencies
         run: pnpm install
+
+      - name: update edge version
+        run: |
+          # Get the current version from Cargo.toml
+          version=$(grep -m 1 '^version = ' backend/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          # Get the short commit SHA
+          commit_sha=$(git rev-parse --short HEAD)
+          # Create the new version string
+          new_version="${version}-${commit_sha}"
+          # Replace the version in Cargo.toml
+          sed -i.bak "s/^version = \"${version}\"/version = \"${new_version}\"/" backend/Cargo.toml
 
       - uses: tauri-apps/tauri-action@v0
         id: tauri-action

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    let channel = std::env::var("APP_CHANNEL").unwrap_or("stable".to_string());
+    println!("cargo:rustc-env=APP_CHANNEL={}", channel);
+
     println!("cargo:rerun-if-changed=migrations");
     tauri_build::build()
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -411,11 +411,27 @@ fn main() {
         }))
     };
 
+    let update_channel = env!("APP_CHANNEL");
+
+    let update_endpoints = if update_channel == "edge" {
+        vec![format!("https://hub.atuin.sh/api/updates/{update_channel}/{{target}}/{{arch}}/{{current_version}}")]
+    } else {
+        vec![
+            "https://releases.atuin.sh/{{target}}/{{arch}}/{{current_version}}",
+            "https://github.com/atuinsh/desktop/releases/latest/download/latest.json",
+            "https://cdn.crabnebula.app/update/atuin/atuin-desktop/{{target}}-{{arch}}/{{current_version}}",
+        ]
+    };
+
     let app = builder
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(
+            tauri_plugin_updater::Builder::new()
+                .endpoints(update_endpoints)
+                .build(),
+        )
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_shell::init())


### PR DESCRIPTION
This modifies the `edge` builder:

* Sets `APP_CHANNEL` environment variable to `edge`
* Sets dynamic update endpoints based on the `APP_CHANNEL` (via `build.rs`)
* Updates the version when building to include the short sha as the "pre" part