### PR TITLE
chore: Add contributors to release notes

### DIFF
--- a/.github/workflows/tauri-release.yaml
+++ b/.github/workflows/tauri-release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           version: latest
-          args: -vv --latest --no-exec --github-repo ${{ github.repository }} --tag-pattern "v.*"
+          args: -vv --latest --no-exec --github-repo ${{ github.repository }} --tag-pattern "v.*" --github-token ${{ github.token }}
 
   draft:
     name: Draft releases

--- a/cliff.toml
+++ b/cliff.toml
@@ -6,9 +6,18 @@
 # A Tera template to be rendered for each release in the changelog.
 # See https://keats.github.io/tera/docs/#introduction
 body = """
+{% set first_time_contributors = github.contributors | filter(attribute="is_first_time", value=true) %}
+{% set ignored_contributors = ["ellie", "BinaryMuse"] %}
 {% if version %}\
     ## Atuin Desktop v{{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% if first_time_contributors | length > 0 %}\
 
+    Special thanks to our contributors who made their first contribution this release:
+
+        {%- for contrib in first_time_contributors %}
+            - [@{{ contrib.username }}](https://github.com/{{ contrib.username }})
+        {%- endfor %}
+    {% endif %}
     ### 🔗 Downloads
     - [macOS ARM](https://github.com/atuinsh/desktop/releases/download/v{{ version | trim_start_matches(pat="v") }}/Atuin_{{ version | trim_start_matches(pat="v") }}_aarch64.dmg)
     - [macOS Intel](https://github.com/atuinsh/desktop/releases/download/v{{ version | trim_start_matches(pat="v") }}/Atuin_{{ version | trim_start_matches(pat="v") }}_x64.dmg)
@@ -25,6 +34,9 @@ body = """
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {{ commit.message | upper_first }}\
+            {% if commit.remote.username and commit.remote.username not in ignored_contributors and commit.remote.username is not ending_with("[bot]") %} \
+            by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})\
+            {% endif %}\
     {% endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
This PR adds contributor information to the generated release notes:

* Adds PR author next to the line item if it's not me, @ellie, or a bot
* Adds a special callout at the top of the notes to any first-time contributors