### PR TITLE
chore: Delete old edge assets when updating release

### DIFF
--- a/.github/workflows/tauri-edge.yaml
+++ b/.github/workflows/tauri-edge.yaml
@@ -37,6 +37,11 @@ jobs:
 
           Latest commit: ${{ github.event.head_commit.message }}
           Built from: ${{ github.sha }}"
+            gh release view edge --json assets | jq -r '.assets[].name' | \
+              while read name; do \
+                echo Deleting existing asset: "$name"
+                gh release delete-asset edge "$name" -y
+              done
           else
             echo "Creating new edge release..."
             gh release create edge \


### PR DESCRIPTION
This ensures we won't incorrectly serve a version that doesn't match the SHA listed in the release body (which is how we determine the version number in the updater service).