### PR TITLE
fix: Allow setting interpreter for Kubernetes block

### DIFF
--- a/src/lib/blocks/kubernetes/component.tsx
+++ b/src/lib/blocks/kubernetes/component.tsx
@@ -48,6 +48,7 @@ import Block from "@/lib/blocks/common/Block";
 import { cn } from "@/lib/utils";
 import { KubernetesBlock } from "./schema";
 import { useCurrentRunbookId } from "@/context/runbook_id_context";
+import InterpreterSelector from "../common/InterpreterSelector";
 
 type KubernetesMode = "preset" | "custom";
 
@@ -89,7 +90,7 @@ export function KubernetesComponent({
   setName,
   setCommand,
   setMode,
-  setInterpreter: _setInterpreter, // Currently not used in the UI but kept for potential future use
+  setInterpreter,
   setAutoRefresh,
   setRefreshInterval,
   setNamespace,
@@ -210,6 +211,14 @@ export function KubernetesComponent({
       type="kubernetes-get"
       setName={setName}
       setDependency={() => {}}
+      topRightElement={
+        <InterpreterSelector
+          interpreter={kubernetes.interpreter}
+          onInterpreterChange={setInterpreter}
+          size="sm"
+          variant="flat"
+        />
+      }
       header={
         <>
           {kubernetes.mode === "preset" ? (

--- a/src/lib/blocks/kubernetes/spec.tsx
+++ b/src/lib/blocks/kubernetes/spec.tsx
@@ -4,6 +4,7 @@ import { createReactBlockSpec } from "@blocknote/react";
 import { KubernetesComponent } from "./component";
 import track_event from "@/tracking";
 import { Container } from "lucide-react";
+import { Settings } from "@/state/settings";
 
 export default createReactBlockSpec(
     KUBERNETES_BLOCK_SCHEMA,
@@ -118,20 +119,23 @@ export const insertKubernetes = (editor: any) => ({
     let kubernetesBlocks = editor.document.filter((block: any) => block.type === "kubernetes-get");
     let name = `Kubernetes Get ${kubernetesBlocks.length + 1}`;
 
-    editor.insertBlocks(
-      [
-        {
-          type: "kubernetes-get",
-          props: {
-            name,
-            command: "kubectl get pods -o json",
-            mode: "preset",
+    Settings.scriptShell().then((shell) => {
+      editor.insertBlocks(
+        [
+          {
+            type: "kubernetes-get",
+            props: {
+              name,
+              command: "kubectl get pods -o json",
+              mode: "preset",
+              interpreter: shell || "zsh",
+            },
           },
-        },
-      ],
-      editor.getTextCursorPosition().block.id,
-      "before",
-    );
+        ],
+        editor.getTextCursorPosition().block.id,
+        "before",
+      );
+    });
   },
   icon: <Container size={18} />,
   aliases: ["kubernetes", "kubernetes-get", "k8s", "kubectl", "pods", "get"],


### PR DESCRIPTION
The Kubernetes block already has a prop for the interpreter, and a callback for setting it, but we weren't using it for anything and it defaulted to "bash" no matter what the default shell was set to in the settings.

This PR:

1. Sets the `interpreter` prop upon block insertion to the default shell, or "zsh" if none is set
2. Adds an interpreter selector component to the Kubernetes block

I'm only _assuming_ this fixes #86, but we can revisit if it turns out it doesn't.

@ellie I want to get your thoughts on this in case you have a different way you'd like to go about it.

Closes #86 