### PR TITLE
fix: Duplicating a block sometimes doesn't duplicate the code in the block

### DIFF
--- a/src/components/runbooks/editor/ui/DuplicateBlockItem.tsx
+++ b/src/components/runbooks/editor/ui/DuplicateBlockItem.tsx
@@ -13,16 +13,19 @@ export function DuplicateBlockItem(props: DragHandleMenuProps) {
   return (
     <Components.Generic.Menu.Item
       onClick={() => {
-        let block = structuredClone(props.block);
+        // HACK [mkt]: For some blocks using CodeMirror, it seems that `props.block`
+        // is missing the code in its props. However, `editor.document` has the correct
+        // value in the block's props. So, we use `editor.document` to get the block.
+        let block = editor.getBlock(props.block.id) || props.block;
+        block = structuredClone(block);
+
         let id = uuidv7();
         block.id = id;
 
-        editor.insertBlocks([block
-
-        ], props.block.id, "after");
-      }}>
+        editor.insertBlocks([block], props.block.id, "after");
+      }}
+    >
       Duplicate
     </Components.Generic.Menu.Item>
   );
 }
-


### PR DESCRIPTION
Inside `DuplicateBlockItem`, blocks with CodeMirror instances sometimes show up with an empty `props.block.props.code`. However, `document.getBlock(props.block.id).props.code` is correct, so we use this when duplicating blocks.