### PR TITLE
fix: test assertions incorrect

### DIFF
--- a/backend/src/workspaces/manager.rs
+++ b/backend/src/workspaces/manager.rs
@@ -1093,7 +1093,7 @@ mod tests {
 
         // Check that no events were generated for gitignored content
         let events = collector.get_events().await;
-        
+
         // Verify that gitignored content is not in the workspace state
         {
             let manager_guard = manager_arc.lock().await;


### PR DESCRIPTION
On some setups, we may receive events for other files in the workspace, and therefore the assertion that we receive no events is not true.

We DO still check that the workspace state does not contain any of the ignored files, so this still verifies functionality.