### PR TITLE
feat: Import runbooks from Atuin Hub when using Open in Desktop

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -22,6 +22,7 @@ type RequestMethod = "GET" | "POST" | "PUT" | "DELETE";
 
 type RequestOpts = {
   token?: string;
+  bodyType?: "json" | "bytes";
 };
 
 async function makeRequest<T>(
@@ -79,7 +80,11 @@ async function makeRequest<T>(
   logger.debug(`${resp.status} (${delta}ms)`);
 
   if (resp.ok && resp.status != 204) {
-    return resp.json();
+    if (options.bodyType == "bytes") {
+      return resp.arrayBuffer() as unknown as T;
+    } else {
+      return resp.json();
+    }
   } else if (resp.status == 204) {
     return {} as T;
   } else {

--- a/src/api/runbooks.ts
+++ b/src/api/runbooks.ts
@@ -15,6 +15,14 @@ export async function getRunbookID(id: string): Promise<RemoteRunbook> {
   return runbook;
 }
 
+export async function getRunbookYdoc(id: string): Promise<Uint8Array | null> {
+  let url = `/runbooks/${id}/yjs`;
+
+  const ydoc = await get<ArrayBuffer>(url, { bodyType: "bytes" });
+
+  return new Uint8Array(ydoc);
+}
+
 export function createRunbook(runbook: Runbook, slug: string, visibility: string) {
   const body = {
     runbook: {

--- a/src/lib/runbook_editor.ts
+++ b/src/lib/runbook_editor.ts
@@ -197,8 +197,11 @@ export default class RunbookEditor {
       if (this.maybeNeedsContentConversion) {
         provider.once("synced").then(() => {
           // If the loaded YJS doc has no content, and the server has no content,
-          // we should take the old `content` field (if any) and populate the editor
+          // we should take the `content` field (if any) and populate the editor
           // so that we trigger a save, creating the YJS document.
+          //
+          // This is common when importing a runbook to an online workspace via
+          // Open in Desktop.
           //
           // This doesn't work if we set the content on the same tick, so defer it.
           setTimeout(() => {

--- a/src/lib/workspaces/strategy.ts
+++ b/src/lib/workspaces/strategy.ts
@@ -30,6 +30,11 @@ export type DoFolderOp = (
  */
 export default interface WorkspaceStrategy {
   createWorkspace(): Promise<Result<Workspace, WorkspaceError>>;
+  importRunbookFromHub(
+    runbookId: string,
+    tag: string,
+    activateRunbook: (runbookId: string) => Promise<void>,
+  ): Promise<Result<string, WorkspaceError>>;
   createRunbook(
     parentFolderId: string | null,
     activateRunbook: (runbookId: string) => Promise<void>,

--- a/src/routes/root/DesktopImportModal.tsx
+++ b/src/routes/root/DesktopImportModal.tsx
@@ -1,0 +1,259 @@
+import { remoteRunbook } from "@/lib/queries/runbooks";
+import { allWorkspaces } from "@/lib/queries/workspaces";
+import { getWorkspaceStrategy } from "@/lib/workspaces/strategy";
+import Workspace from "@/state/runbooks/workspace";
+import { useStore } from "@/state/store";
+import { ConnectionState } from "@/state/store/user_state";
+import {
+  Button,
+  cn,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Spinner,
+} from "@heroui/react";
+import { useQuery } from "@tanstack/react-query";
+import { DynamicIcon } from "lucide-react/dynamic";
+import { useLayoutEffect, useMemo, useReducer, useState } from "react";
+
+interface DesktopImportModalProps {
+  runbookId: string;
+  tag: string;
+  activateRunbook: (runbookId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function DesktopImportModal(props: DesktopImportModalProps) {
+  const connectionState = useStore((state) => state.connectionState);
+  const currentWorkspaceId = useStore((state) => state.currentWorkspaceId);
+  const workspaces = useQuery(allWorkspaces());
+  const remoteRunbookQuery = useQuery(remoteRunbook(props.runbookId));
+
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(currentWorkspaceId);
+  const selectedWorkspace = useMemo(() => {
+    return workspaces.data?.find((ws) => ws.get("id") === selectedWorkspaceId) ?? null;
+  }, [workspaces.data, selectedWorkspaceId]);
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  function handleClose() {
+    props.onClose();
+  }
+
+  async function confirmImportRunbook() {
+    if (!selectedWorkspaceId) return;
+
+    setImportError(null);
+    setImporting(true);
+
+    try {
+      const workspace = await Workspace.get(selectedWorkspaceId);
+      if (!workspace) {
+        throw new Error("Not able to load target workspace");
+      }
+
+      if (workspace.isOnline() && !workspace.canManageRunbooks()) {
+        throw new Error("You do not have permission to manage runbooks in the target workspace");
+      }
+
+      const strategy = getWorkspaceStrategy(workspace);
+      const result = await strategy.importRunbookFromHub(
+        props.runbookId,
+        props.tag,
+        props.activateRunbook,
+      );
+      if (result.isErr()) {
+        const err = result.unwrapErr();
+        if ("message" in err.data) {
+          throw new Error(err.data.message);
+        }
+        throw new Error("Failed to create runbook in the target workspace");
+      }
+
+      props.onClose();
+    } catch (error) {
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : typeof error === "string"
+          ? error
+          : "An unknown error occurred",
+      );
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  const failed = remoteRunbookQuery.isError || workspaces.isError;
+  const ready = remoteRunbookQuery.isSuccess && workspaces.isSuccess;
+
+  let body: React.ReactNode | null = null;
+
+  if (importing) {
+    body = (
+      <div className="flex flex-col items-center justify-center gap-2">
+        <p>Importing runbook...</p>
+      </div>
+    );
+  } else if (importError) {
+    body = (
+      <p>
+        Failed to import the runbook: <strong>{importError}</strong>
+      </p>
+    );
+  } else if (failed) {
+    body = (
+      <p>
+        Failed to load runbook information. The runbook may not exist or you may not have permission
+        to access it.
+      </p>
+    );
+  } else if (!ready) {
+    if (
+      connectionState !== ConnectionState.Online &&
+      connectionState !== ConnectionState.LoggedOut
+    ) {
+      body = <p>You must be online to import a runbook.</p>;
+    } else {
+      body = (
+        <div className="flex flex-col items-center justify-center gap-2">
+          <Spinner />
+          <p>Loading runbook information...</p>
+        </div>
+      );
+    }
+  }
+
+  return (
+    <Modal isOpen onClose={handleClose}>
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader>Import Runbook</ModalHeader>
+            {body && <ModalBody>{body}</ModalBody>}
+            {!body && (
+              <ModalBody>
+                <p>
+                  To open the runbook <strong>{remoteRunbookQuery.data?.name}</strong>@
+                  <strong>{props.tag}</strong>, you need to import it into a workspace. Choose a
+                  workspace below to import it into.
+                </p>
+                {
+                  <WorkspaceSelector
+                    workspaces={workspaces.data ?? []}
+                    selectedWorkspace={selectedWorkspace}
+                    onSelect={setSelectedWorkspaceId}
+                  />
+                }
+              </ModalBody>
+            )}
+            <ModalFooter>
+              <Button onPress={onClose}>Cancel</Button>
+              <Button
+                onPress={confirmImportRunbook}
+                color="primary"
+                isDisabled={failed || !ready || !selectedWorkspaceId || importing}
+                isLoading={importing}
+              >
+                Import
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+interface WorkspaceSelectorProps {
+  workspaces: Workspace[];
+  selectedWorkspace: Workspace | null;
+  onSelect: (workspaceId: string) => void;
+}
+
+function defaultWorkspaceSelectorState(
+  selectedWorkspaceId: string | null,
+): Record<string, boolean> {
+  if (!selectedWorkspaceId) {
+    return {};
+  }
+
+  return {
+    [selectedWorkspaceId]: true,
+  };
+}
+
+function collapseReducer(state: Record<string, boolean>, action: { type: "toggle"; id: string }) {
+  return {
+    ...state,
+    [action.id]: !state[action.id],
+  };
+}
+
+function WorkspaceSelector(props: WorkspaceSelectorProps) {
+  const orgs = useStore((state) => state.userOrgs);
+
+  const [uncollapsed, dispatchCollapse] = useReducer(
+    collapseReducer,
+    defaultWorkspaceSelectorState(props.selectedWorkspace?.get("orgId") ?? "<PERSONAL>"),
+  );
+
+  const orgsDisplay = [
+    { name: "Personal", id: "<PERSONAL>" },
+    ...orgs.map((org) => ({ name: org.name, id: org.id })),
+  ];
+  const workspacesPerOrg = orgsDisplay.reduce((acc, org) => {
+    acc[org.id] = props.workspaces.filter(
+      (ws) =>
+        ws.get("orgId") === (org.id == "<PERSONAL>" ? null : org.id) && ws.canManageRunbooks(),
+    );
+    return acc;
+  }, {} as Record<string, Workspace[]>);
+
+  useLayoutEffect(() => {
+    if (props.selectedWorkspace) {
+      const workspaceElement = document.getElementById(
+        `import-workspace-selector-${props.selectedWorkspace.get("id")}`,
+      );
+      if (workspaceElement) {
+        workspaceElement.scrollIntoView({ behavior: "smooth" });
+      }
+    }
+  }, []);
+
+  return (
+    <div className="max-h-[200px] overflow-y-auto">
+      {orgsDisplay.map((org) => (
+        <ul key={org.id}>
+          <p
+            className="cursor-pointer font-bold"
+            onClick={() => dispatchCollapse({ type: "toggle", id: org.id })}
+          >
+            <DynamicIcon
+              name={uncollapsed[org.id] ? "chevron-down" : "chevron-right"}
+              className="w-4 h-4 inline-block"
+            />
+            {org.name}
+          </p>
+          <ul className={cn("ml-4 mb-2", uncollapsed[org.id] ? "block" : "hidden")}>
+            {workspacesPerOrg[org.id]?.map((ws) => (
+              <li
+                key={ws.get("id")}
+                id={`import-workspace-selector-${ws.get("id")}`}
+                className={cn(
+                  "cursor-pointer",
+                  props.selectedWorkspace?.get("id") === ws.get("id") ? "text-blue-500" : "",
+                )}
+                onClick={() => props.onSelect(ws.get("id")!)}
+              >
+                {ws.get("name")}
+              </li>
+            ))}
+          </ul>
+        </ul>
+      ))}
+    </div>
+  );
+}

--- a/src/routes/root/Root.tsx
+++ b/src/routes/root/Root.tsx
@@ -79,6 +79,7 @@ import { getGlobalOptions } from "@/lib/global_options";
 import SaveBlockModal from "./SaveBlockModal";
 import SavedBlock from "@/state/runbooks/saved_block";
 import { uuidv7 } from "uuidv7";
+import DesktopImportModal from "./DesktopImportModal";
 
 const globalOptions = getGlobalOptions();
 const UPDATE_CHECK_INTERVAL = globalOptions.channel === "edge" ? 1000 * 60 * 5 : 1000 * 60 * 60;
@@ -129,6 +130,8 @@ function App() {
   const refreshRunbooks = useStore((state: AtuinState) => state.refreshRunbooks);
   const currentWorkspaceId = useStore((state: AtuinState) => state.currentWorkspaceId);
   const setCurrentWorkspaceId = useStore((state: AtuinState) => state.setCurrentWorkspaceId);
+  const openInDesktopImport = useStore((state: AtuinState) => state.openInDesktopImport);
+  const setOpenInDesktopImport = useStore((state: AtuinState) => state.setOpenInDesktopImport);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showInviteFriends, setShowInviteFriends] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -1195,6 +1198,14 @@ function App() {
             block={savingBlock.unwrap()}
             onClose={clearSavingBlock}
             doSaveBlock={handleSaveBlock}
+          />
+        )}
+        {openInDesktopImport && (
+          <DesktopImportModal
+            runbookId={openInDesktopImport.id}
+            tag={openInDesktopImport.tag}
+            onClose={() => setOpenInDesktopImport(null)}
+            activateRunbook={navigateToRunbook}
           />
         )}
       </RunbookContext.Provider>

--- a/src/routes/root/deep.ts
+++ b/src/routes/root/deep.ts
@@ -1,81 +1,47 @@
 import { me, HttpResponseError } from "@/api/api";
-import { DialogBuilder } from "@/components/Dialogs/dialog";
 import Runbook from "@/state/runbooks/runbook";
 import { useStore } from "@/state/store";
 
-interface RouteHandler {
-  (params: string[]): void;
-}
-
-interface Routes {
-  [pattern: string]: RouteHandler;
-}
-
-const handleDeepLink = (url: string, openRunbook: (id: string) => void): void | null => {
-  const routes: Routes = {
-    // New "Open in desktop" from the hub
-    "^atuin://runbook/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$": async (
-      params: string[],
-    ) => {
-      const [id] = params;
-
-      const runbook = await Runbook.load(id);
-      if (runbook) {
-        openRunbook(runbook.id);
-      } else {
-        await new DialogBuilder()
-          .title("Runbook not found")
-          .message("The runbook you are trying to open was not found on this machine.")
-          .action({ label: "OK", value: "ok", variant: "flat" })
-          .build();
-      }
-    },
-
-    // Register an auth token with this desktop app
-    "^atuin://register-token/(atapi_[0-9A-F]+)$": async (params: string[]) => {
-      const [token] = params;
-
-      try {
-        // Hit the "me" endpoint to verify the token and fetch username
-        let user = await me(token);
-
-        useStore.getState().setProposedDesktopConnectuser({ username: user.user.username, token });
-      } catch (err) {
-        if (err instanceof HttpResponseError) {
-          console.error("Failed to verify token:", err.code);
-        } else {
-          console.error("Failed to verify token:", err);
-        }
-      }
-    },
-  };
-
-  // If no URL provided, return early
-  if (!url) {
+const handleDeepLink = async (
+  url: string,
+  openRunbook: (id: string) => void,
+): Promise<void | null> => {
+  const uri = URL.parse(url);
+  if (!uri) {
     return null;
   }
 
-  // Try to match the URL against each route pattern
-  for (const [pattern, handler] of Object.entries(routes)) {
-    const regex = new RegExp(pattern, "i");
-    const match = url.match(regex);
+  if (uri.host === "runbook") {
+    const runbookId = uri.pathname.substring(1); // drop leading slash
+    const tag = uri.searchParams.get("tag") || "latest";
 
-    if (match) {
-      // Extract the captured groups (excluding the full match)
-      const params = match.slice(1);
+    const runbook = await Runbook.load(runbookId);
+    if (runbook) {
+      openRunbook(runbook.id);
+      return;
+    } else {
+      // If we're in the middle of importing, don't show the dialog
+      if (useStore.getState().openInDesktopImport) {
+        return;
+      }
+      useStore.getState().setOpenInDesktopImport({ id: runbookId, tag });
+    }
+  } else if (uri.host === "register-token") {
+    const token = uri.pathname.substring(1); // drop leading slash
 
-      try {
-        return handler(params);
-      } catch (error) {
-        console.error(`Error handling route for URL ${url}:`, error);
-        return null;
+    try {
+      // Hit the "me" endpoint to verify the token and fetch username
+      let user = await me(token);
+
+      useStore.getState().setProposedDesktopConnectuser({ username: user.user.username, token });
+    } catch (err) {
+      if (err instanceof HttpResponseError) {
+        console.error("Failed to verify token:", err.code);
+      } else {
+        console.error("Failed to verify token:", err);
       }
     }
   }
-
-  // No matching route found
-  console.warn(`No matching route found for URL: ${url}`);
-  return null;
 };
 
 export default handleDeepLink;

--- a/src/routes/runbooks/Runbooks.tsx
+++ b/src/routes/runbooks/Runbooks.tsx
@@ -391,11 +391,6 @@ export default function Runbooks() {
   }
 
   useEffect(() => {
-    if (lastRunbookEditor.current) {
-      lastRunbookEditor.current.shutdown();
-      setRunbookEditor(null);
-    }
-
     if (!currentRunbook || !runbookWorkspace) {
       return;
     }
@@ -412,6 +407,13 @@ export default function Runbooks() {
     lastRunbookEditor.current = newRunbookEditor;
     setEditorKey((prev) => !prev);
     setRunbookEditor(newRunbookEditor);
+
+    return () => {
+      if (lastRunbookEditor.current) {
+        lastRunbookEditor.current.shutdown();
+        setRunbookEditor(null);
+      }
+    };
   }, [currentRunbook?.id, runbookWorkspace?.get("id")]);
 
   useEffect(() => {

--- a/src/state/models.ts
+++ b/src/state/models.ts
@@ -185,6 +185,7 @@ export interface RemoteRunbook {
   snapshots: RemoteSnapshot[];
   collaborations: RemoteCollaboration[];
   permissions: string[];
+  content?: any[];
 }
 
 // Define other interfaces (Dialect, Timezone, Style, SearchMode, FilterMode, ExitMode, KeymapMode, CursorStyle, WordJumpMode, RegexSet, Stats) accordingly.

--- a/src/state/runbooks/runbook.ts
+++ b/src/state/runbooks/runbook.ts
@@ -528,7 +528,7 @@ export class OnlineRunbook extends Runbook {
     });
   }
 
-  public static async saveYDocForRunbook(id: string, update: ArrayBuffer | null) {
+  public static async saveYDocForRunbook(id: string, update: Uint8Array | null) {
     if (update) {
       logger.time(`Saving Y.Doc for runbook ${id}...`, async () => {
         await invoke("save_ydoc_for_runbook", update, {

--- a/src/state/store/runbook_state.ts
+++ b/src/state/store/runbook_state.ts
@@ -14,6 +14,7 @@ export interface AtuinRunbookState {
   lastTagForRunbook: { [key: string]: string };
   backgroundSync: boolean;
   syncConcurrency: number;
+  openInDesktopImport: { id: string; tag: string } | null;
 
   importRunbooks: () => Promise<string[]>;
   refreshRunbooks: () => Promise<void>;
@@ -28,6 +29,8 @@ export interface AtuinRunbookState {
 
   setBackgroundSync: (backgroundSync: boolean) => void;
   setSyncConcurrency: (syncConcurrency: number) => void;
+
+  setOpenInDesktopImport: (toImport: { id: string; tag: string } | null) => void;
 }
 
 export const persistRunbookKeys: (keyof AtuinRunbookState)[] = [
@@ -47,6 +50,7 @@ export const createRunbookState: StateCreator<AtuinRunbookState> = (
   serialExecution: [],
   backgroundSync: true,
   syncConcurrency: 1,
+  openInDesktopImport: null,
 
   importRunbooks: async (): Promise<string[]> => {
     let filePath = await open({
@@ -116,5 +120,9 @@ export const createRunbookState: StateCreator<AtuinRunbookState> = (
 
   setSyncConcurrency: (syncConcurrency: number) => {
     set({ syncConcurrency });
+  },
+
+  setOpenInDesktopImport: (toImport: { id: string; tag: string } | null) => {
+    set({ openInDesktopImport: toImport });
   },
 });


### PR DESCRIPTION
This PR improves the "Open in Desktop" flow to import runbooks that don't already exist into a user's Desktop instance.

The user is prompted to choose a workspace to import the runbook into, with the current selected workspace pre-selected. If the user chooses an online workspace, we import the runbook and all tags; if the user chooses an offline workspace, it only imports the tag specified by the URL (`?tag=tagname`).