### PR TITLE
fix: Use more robust method for creating the Welcome workspace

### DIFF
--- a/src/lib/workspace_setup.ts
+++ b/src/lib/workspace_setup.ts
@@ -10,7 +10,6 @@ import { AtuinSharedStateAdapter } from "./shared_state/adapter";
 import { uuidv7 } from "uuidv7";
 import Logger from "./logger";
 import { Rc } from "@binarymuse/ts-stdlib";
-import { createWorkspace } from "./workspaces/commands";
 import { TabIcon } from "@/state/store/ui_state";
 import { invoke } from "@tauri-apps/api/core";
 import { DialogBuilder } from "@/components/Dialogs/dialog";
@@ -57,8 +56,9 @@ export default async function doWorkspaceSetup(): Promise<void> {
       logger.info("Unable to fetch workspaces from server; creating default workspace");
 
       let workspacePath: string | null = null;
+      let welcomeWorkspaceId = uuidv7();
       try {
-        workspacePath = await invoke<string>("copy_welcome_workspace");
+        workspacePath = await invoke<string>("copy_welcome_workspace", { id: welcomeWorkspaceId });
       } catch (err) {
         await new DialogBuilder()
           .title("Failed to create welcome workspace")
@@ -72,14 +72,12 @@ export default async function doWorkspaceSetup(): Promise<void> {
       }
 
       let name = "Welcome to Atuin";
-      let id = uuidv7();
       workspace = new Workspace({
-        id: id,
+        id: welcomeWorkspaceId,
         name: name,
         folder: workspacePath,
         online: 0,
       });
-      await createWorkspace(workspacePath, id, name);
       await workspace.save();
     }
 


### PR DESCRIPTION
Folks on some *nix systems report the welcome workspace not working upon first start; the workspace ID in the database and the one in the `atuin.toml` file don't seem to match.

This PR updates the workspace setup to use a more robust method to try to ensure these IDs match.