### PR TITLE
chore: always run rust ci on main

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   push:
     branches: [main]
-    paths:
-      - "backend/**"
-      - ".github/**"
 
   pull_request:
     paths:


### PR DESCRIPTION
We missed failing Rust ci in the past because we were only running it on Rust changes for main. Always run all tests on main, run selective tests on PRs.