### PR TITLE
fix: mysql enum

### DIFF
--- a/backend/src/runtime/blocks/mysql/decode.rs
+++ b/backend/src/runtime/blocks/mysql/decode.rs
@@ -26,7 +26,7 @@ pub(crate) fn to_json(v: MySqlValueRef) -> Result<JsonValue> {
     }
 
     let res = match v.type_info().name() {
-        "VARCHAR" | "CHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" => {
+        "VARCHAR" | "CHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" | "ENUM" => {
             match ValueRef::to_owned(&v).try_decode::<String>() {
                 Ok(v) => JsonValue::String(v),
                 _ => JsonValue::Null,


### PR DESCRIPTION
## Change Summary
Fix returning enums for MySQL. Resolve #22.

## Motivation and details
This is a simple fix since in MySQL enums are stored as [strings](https://dev.mysql.com/doc/refman/8.4/en/string-type-syntax.html).

Tested with the [example](https://dev.mysql.com/doc/refman/8.4/en/enum.html) in the MySQL enum doc.

```sql
CREATE TABLE shirts (
    name VARCHAR(40),
    size ENUM('x-small', 'small', 'medium', 'large', 'x-large')
);

INSERT INTO shirts (name, size) VALUES ('dress shirt','large'), ('t-shirt','medium'),
  ('polo shirt','small');

SELECT name, size FROM shirts WHERE size = 'medium';
```

## Tasks
- [x] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [x] Updated the documentation in `docs/` (if any application behavior has changed)
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
