### PR TITLE
feat: allow for specifying custom agent socket path

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -782,6 +782,35 @@ const AISettings = () => {
   );
 };
 
+const SSHSettings = () => {
+  const [sshAgentSocket, setSshAgentSocket, socketLoading] = useSettingsState(
+    "ssh_agent_socket",
+    "",
+    Settings.sshAgentSocket,
+    Settings.sshAgentSocket,
+  );
+
+  if (socketLoading) return <Spinner />;
+
+  return (
+    <Card shadow="sm">
+      <CardBody className="flex flex-col gap-4">
+        <h2 className="text-xl font-semibold">SSH</h2>
+        <p className="text-sm text-default-500">Configure SSH connection settings</p>
+
+        <SettingInput
+          type="text"
+          label="SSH Agent Socket"
+          value={sshAgentSocket || ""}
+          onChange={setSshAgentSocket}
+          placeholder="/run/user/1000/keyring/ssh or ~/custom-agent.sock"
+          description="Custom SSH agent socket path (leave empty to use SSH_AUTH_SOCK environment variable)"
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
 const UserSettings = () => {
   const user = useStore((state) => state.user);
   const refreshUser = useStore((state) => state.refreshUser);
@@ -874,6 +903,7 @@ const SettingsPanel = () => {
       <div className="flex flex-col gap-4">
         <GeneralSettings />
         <RunbookSettings />
+        <SSHSettings />
         <AISettings />
         <UserSettings />
       </div>

--- a/src/components/runbooks/editor/blocks/Script/Script.tsx
+++ b/src/components/runbooks/editor/blocks/Script/Script.tsx
@@ -17,6 +17,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 import { findAllParentsOfType, findFirstParentOfType, getCurrentDirectory } from "@/lib/blocks/exec.ts";
 import { templateString } from "@/state/templates.ts";
+import { Settings } from "@/state/settings.ts";
 import { Command } from "@codemirror/view";
 import { ScriptBlock as ScriptBlockType } from "@/lib/workflow/blocks/script.ts";
 import { default as BlockType } from "@/lib/workflow/blocks/block.ts";
@@ -32,7 +33,6 @@ import { useBlockDeleted } from "@/lib/buses/editor.ts";
 import { useBlockInserted } from "@/lib/buses/editor.ts";
 import track_event from "@/tracking";
 import { invoke } from "@tauri-apps/api/core";
-import { Settings } from "@/state/settings.ts";
 import PlayButton from "@/lib/blocks/common/PlayButton.tsx";
 import CodeEditor, { TabAutoComplete } from "@/lib/blocks/common/CodeEditor/CodeEditor.tsx";
 import Block from "@/lib/blocks/common/Block.tsx";
@@ -336,12 +336,15 @@ const ScriptBlock = ({
           onStop();
         });
 
+        const customAgentSocket = await Settings.sshAgentSocket();
+
         await invoke<string>("ssh_exec", {
           host: host,
           username: username,
           command: command,
           interpreter: interpreterCommand,
           channel: channel,
+          customAgentSocket,
         });
         SSHBus.get().updateConnectionStatus(connectionBlock.props.userHost, "success");
       } catch (error) {

--- a/src/components/runbooks/editor/blocks/ssh/ssh.ts
+++ b/src/components/runbooks/editor/blocks/ssh/ssh.ts
@@ -3,6 +3,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import SSHBus from "@/lib/buses/ssh";
 import { addToast } from "@heroui/react";
+import { Settings } from "@/state/settings";
 
 export async function sshConnect(userHost: string): Promise<void> {
   let username: string | undefined;
@@ -21,7 +22,14 @@ export async function sshConnect(userHost: string): Promise<void> {
     // Set status to idle while connecting
     SSHBus.get().updateConnectionStatus(userHost, "idle");
     
-    await invoke("ssh_connect", { username, host });
+    // Get custom SSH agent socket from settings (if configured)
+    const customAgentSocket = await Settings.sshAgentSocket();
+    
+    await invoke("ssh_connect", { 
+      username, 
+      host,
+      customAgentSocket,
+    });
     
     // If successful, update the status
     SSHBus.get().updateConnectionStatus(userHost, "success");

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -12,6 +12,7 @@ const AI_ENABLED = "settings.ai.enabled";
 const AI_API_KEY = "settings.ai.api_key";
 const SHELLCHECK_ENABLED = "settings.editor.shellcheck.enabled";
 const SHELLCHECK_PATH = "settings.editor.shellcheck.path";
+const SSH_AGENT_SOCKET = "settings.ssh.agent_socket";
 
 export class Settings {
   public static DEFAULT_FONT = "FiraCode";
@@ -147,5 +148,16 @@ export class Settings {
     }
 
     return await store.get(SHELLCHECK_PATH);
+  }
+
+  public static async sshAgentSocket(val: string | null = null): Promise<string | null> {
+    let store = await KVStore.open_default();
+
+    if (val || val === "") {
+      await store.set(SSH_AGENT_SOCKET, val);
+      return val;
+    }
+
+    return await store.get(SSH_AGENT_SOCKET);
   }
 }


### PR DESCRIPTION
Allow specifying a global SSH socket path in settings. Soon, we will allow overriding this per-block. Ssh config file IdentityAgent takes priority