### PR TITLE
feat: add block copy/paste

### DIFF
--- a/src/components/runbooks/editor/ui/CopyBlockItem.tsx
+++ b/src/components/runbooks/editor/ui/CopyBlockItem.tsx
@@ -1,0 +1,25 @@
+import { DragHandleMenuProps, useBlockNoteEditor, useComponentsContext } from "@blocknote/react";
+import { ClipboardCopyIcon } from "lucide-react";
+import { useStore } from "@/state/store";
+import { uuidv7 } from "uuidv7";
+
+export function CopyBlockItem(props: DragHandleMenuProps) {
+  const editor = useBlockNoteEditor();
+  const Components = useComponentsContext()!;
+
+  return (
+    <Components.Generic.Menu.Item
+      icon={<ClipboardCopyIcon size={16} />}
+      onClick={() => {
+        // This is the same workaround as in DuplicateBlockItem.
+        let block = editor.getBlock(props.block.id) || props.block;
+        block = structuredClone(block);
+        block.id = uuidv7();
+        useStore.getState().setCopiedBlock(block);
+      }}
+    >
+      Copy
+    </Components.Generic.Menu.Item>
+  );
+}
+

--- a/src/state/store/ui_state.ts
+++ b/src/state/store/ui_state.ts
@@ -60,6 +60,7 @@ export interface AtuinUiState {
   lastSidebarDragInfo: { itemIds: string[]; sourceWorkspaceId: string } | undefined;
   didSidebarSetup: boolean;
   savingBlock: Option<any>;
+  copiedBlock: Option<any>;
 
   tabs: Tab[];
   currentTabId: string | null;
@@ -106,6 +107,8 @@ export interface AtuinUiState {
   registerTabOnClose: (id: string, callback: (tab: Tab) => Promise<boolean>) => void;
   setSavingBlock: (block: any) => void;
   clearSavingBlock: () => void;
+  setCopiedBlock: (block: any) => void;
+  clearCopiedBlock: () => void;
 
   setLightModeEditorTheme: (theme: string) => void;
   setDarkModeEditorTheme: (theme: string) => void;
@@ -162,6 +165,7 @@ export const createUiState: StateCreator<AtuinUiState> = (set, get, _store): Atu
   lastSidebarDragInfo: undefined,
   didSidebarSetup: false,
   savingBlock: None,
+  copiedBlock: None,
 
   tabs: [],
   currentTabId: null,
@@ -385,6 +389,8 @@ export const createUiState: StateCreator<AtuinUiState> = (set, get, _store): Atu
 
   setSavingBlock: (block: any) => set(() => ({ savingBlock: Some(block) })),
   clearSavingBlock: () => set(() => ({ savingBlock: None })),
+  setCopiedBlock: (block: any) => set(() => ({ copiedBlock: Some(block) })),
+  clearCopiedBlock: () => set(() => ({ copiedBlock: None })),
 
   setLightModeEditorTheme: (theme: string) => set(() => ({ lightModeEditorTheme: theme })),
   setDarkModeEditorTheme: (theme: string) => set(() => ({ darkModeEditorTheme: theme })),


### PR DESCRIPTION
Add copy/paste block functionality. Copy from the side menu, paste from the slash menu