### PR TITLE
fix: Ensure Dropdown executes regardless of option type

### DIFF
--- a/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
+++ b/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
@@ -337,7 +337,7 @@ const Dropdown = ({
             onOpenChange={(open) => {
               setComboboxOpen(open);
               // Refresh options when dropdown is opened
-              if (open && (optionsType === "variable" || optionsType === "command")) {
+              if (open) {
                 execution?.execute();
               }
             }}


### PR DESCRIPTION
Fixes a bug where the dropdown would not have any options if the option type was "fixed"