### PR TITLE
Remove new profile.release options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,3 @@ url = "2.4"
 glob = "0.3"
 bigdecimal = "0.4"
 nix = { version = "0.29.0", features = ["signal"] }
-
-[profile.release]
-codegen-units = 1 # Allows LLVM to perform better optimization
-lto = true        # Enables link-time optimizations
-opt-level = 3     # Prioritizes speed over size
-strip = true      # Ensures debug symbols are removed


### PR DESCRIPTION
We can consider adding some of these back once we track down where the performance/compilation slowness is coming from.