### PR TITLE
Duplicate version in backend/Cargo.toml for CN CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-desktop"
-version = "0.2.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "atuin-client",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-desktop-runtime"
-version = "0.2.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "atuin-desktop-templates",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-desktop-templates"
-version = "0.2.0"
+version = "0.1.11"
 dependencies = [
  "minijinja",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["backend", "crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.11"                                # NOTE - also update this in backend/Cargo.toml if not using `cargo workspaces`
 edition = "2021"
 authors = ["ellie@atuin.sh", "michelle@atuin.sh"]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,7 +3,7 @@ name = "atuin-desktop"
 description = "Atuin Desktop"
 publish = false
 workspace = ".."
-version.workspace = true
+version = "0.1.11"            # duplicated here as CN CLI can't handle workspace version
 edition.workspace = true
 
 [lints.clippy]


### PR DESCRIPTION
The CrabNebula CLI can't handle a `version.workspace` in `backend/Cargo.toml`, so this PR replaces it with a duplicated version number.

These can all be updated in the release runbook via `cargo workspaces version --all -y --no-git-commit <type>`

We can hold off on merging this until edge builds are done and updated.