### PR TITLE
fix(runtime): Only emit context change events if the context has actually changed

### DIFF
--- a/crates/atuin-desktop-runtime/src/context/resolution.rs
+++ b/crates/atuin-desktop-runtime/src/context/resolution.rs
@@ -13,7 +13,7 @@ use crate::{
 /// A struct representing the resolved context of a block.
 /// Since it's built from a `ContextResolver`, it's a snapshot
 /// of the final context based on the blocks above it.
-#[derive(Debug, Clone, Serialize, Deserialize, TS, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS, Default, PartialEq)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedContext {


### PR DESCRIPTION
When the `Document` struct on the backend is updated — which happens as often as the backend can keep up — it emits a `BlockContextUpdate` to the frontend with the new context unconditionally. The frontend receives this via `useBlockContext` and updates some local state, which causes components to re-render.

In particular, the `CodeMirror` component uses the block context to set up its autocompletion for template variables. Since we're emitting events unconditionally, the CodeMirror instance is constantly reinitializing itself.

This PR changes the runtime to only emit context update events for a block if the context is not equal to the last context event it sent for that same block. This should avoid a large number of re-renders on the frontend.