### PR TITLE
style: Adjust BlockNote editor style to be slightly less compact

### DIFF
--- a/src/components/runbooks/editor/index.css
+++ b/src/components/runbooks/editor/index.css
@@ -39,3 +39,25 @@
     font-size: 0.9em;
     color: currentColor;
 }
+
+.bn-container > div[data-floating-ui-focusable] {
+    left: -1rem !important;
+}
+
+.bn-block-group {
+    margin-left: 1rem !important;
+}
+
+/* Heading indentation */
+.bn-block-group .bn-block-outer .bn-block .bn-block-content[data-content-type="heading"] {
+    margin-left: -1rem !important;
+}
+
+/* Extra space above headings (not the first block) - use padding on block-outer
+   so the floating UI aligns with the content, not the spacing */
+.bn-block-group .bn-block-outer:not(:first-child):has(.bn-block-content[data-content-type="heading"]) {
+    padding-top: 0.5em !important;
+}
+.bn-block-group .bn-block-outer:has(.bn-block-content[data-content-type="paragraph"]) {
+    margin-top: 0.25em !important;
+}


### PR DESCRIPTION
This PR adjust the BlockNote editor styles to match the new Hub styles a little more:

* Slight negative left margin on headings
* Slight vertical line spacing above headers
* Very slight top margin on paragraphs
* Slight negative left margin on the floating block controls to make everything line up

This has a minimal effect on how much content is shown on a screen, but lets the content breathe just a little more and feel less crowded.

Before:

<img width="3248" height="2112" alt="image" src="https://github.com/user-attachments/assets/1bd3caa4-c90b-47d9-b439-1f6f212afd31" />

After:

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/e98f0483-7f20-4e1b-9abc-cc129efc99d7" />

