### PR TITLE
fix: `.desktop` file doesn't pass arguments in Exec

### DIFF
--- a/backend/AtuinDesktop.desktop
+++ b/backend/AtuinDesktop.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Categories={{ categories }}
 Comment={{ comment }}
-Exec={{ exec }}
+Exec={{ exec }} %u
 Icon={{ icon }}
 Name={{ name }}
 Terminal=false


### PR DESCRIPTION
Fixe by adding `%u` to the `Exec` line in `AtuinDesktop.desktop`. Thanks @JokerQyou

Fixes #236 