### PR TITLE
feat: inherit CWD as default cwd

### DIFF
--- a/crates/atuin-desktop-runtime/src/context/resolution.rs
+++ b/crates/atuin-desktop-runtime/src/context/resolution.rs
@@ -259,7 +259,15 @@ impl ContextResolver {
 }
 
 fn default_cwd() -> String {
-    // Defaults to home directory because placeholder in directory blocks is `~`
+    // Check for PWD env var first (set by shell, reflects current directory)
+    // This allows CLI tools to inherit the user's current working directory
+    // Falls back to home directory for desktop app / GUI contexts
+    if let Ok(pwd) = std::env::var("PWD") {
+        if !pwd.is_empty() {
+            return pwd;
+        }
+    }
+
     dirs::home_dir()
         .or(std::env::current_dir().ok())
         .unwrap_or("/".into())


### PR DESCRIPTION
In the desktop app, CWD is not set. This means the runtime will fallback to using the home direcotry as the default.

In a CLI environment, the runner will inherit the CWD from the shell. This will feel much more natural to users, and be what they expect.

