### PR TITLE
style: update block type labels to subdued monospace styling

### DIFF
--- a/src/components/runbooks/editor/blocks/Directory/index.tsx
+++ b/src/components/runbooks/editor/blocks/Directory/index.tsx
@@ -28,32 +28,35 @@ const Directory = ({ path, onInputChange, isEditable }: DirectoryProps) => {
         content="Change working directory for all subsequent code blocks (shared with collaborators)"
         delay={1000}
       >
-        <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-slate-800 dark:to-blue-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200">
-          <div className="flex items-center">
-            <Button
-              isIconOnly
-              variant="light"
-              className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
-              aria-label="Select folder"
-              onPress={selectFolder}
-              disabled={!isEditable}
-            >
-              <FolderInputIcon className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="flex flex-col w-full bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-slate-800 dark:to-blue-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200">
+          <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">directory</span>
+          <div className="flex flex-row items-center space-x-3">
+            <div className="flex items-center">
+              <Button
+                isIconOnly
+                variant="light"
+                className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
+                aria-label="Select folder"
+                onPress={selectFolder}
+                disabled={!isEditable}
+              >
+                <FolderInputIcon className="h-4 w-4" />
+              </Button>
+            </div>
 
-          <div className="flex-1">
-            <Input
-              placeholder="~ (working directory shared with collaborators)"
-              value={path}
-              autoComplete="off"
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck="false"
-              onValueChange={onInputChange}
-              disabled={!isEditable}
-              className="flex-1 border-blue-200 dark:border-blue-800 focus:ring-blue-500"
-            />
+            <div className="flex-1">
+              <Input
+                placeholder="~ (working directory shared with collaborators)"
+                value={path}
+                autoComplete="off"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck="false"
+                onValueChange={onInputChange}
+                disabled={!isEditable}
+                className="flex-1 border-blue-200 dark:border-blue-800 focus:ring-blue-500"
+              />
+            </div>
           </div>
         </div>
       </Tooltip>

--- a/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
+++ b/src/components/runbooks/editor/blocks/Dropdown/Dropdown.tsx
@@ -320,102 +320,105 @@ const Dropdown = ({
     <>
       <div
         ref={() => setExecutionReady(true)}
-        className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-slate-800 dark:to-cyan-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200"
+        className="flex flex-col w-full bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-slate-800 dark:to-cyan-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200"
       >
-        <div className="flex items-center">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
-            onClick={onOpen}
-          >
-            <ListFilterIcon className="h-4 w-4" />
-          </Button>
-        </div>
+        <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">dropdown</span>
+        <div className="flex flex-row items-center space-x-3">
+          <div className="flex items-center">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
+              onClick={onOpen}
+            >
+              <ListFilterIcon className="h-4 w-4" />
+            </Button>
+          </div>
 
-        <div className="flex-1">
-          <Input
-            placeholder="Template variable name"
-            value={name}
-            onChange={(e) => onNameUpdate(e.target.value)}
-            style={{ fontFamily: "monospace" }}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-            className={`bg-default-100 ${
-              hasNameError
-                ? "border-red-400 dark:border-red-400 focus:ring-red-500"
-                : "border-blue-200 dark:border-blue-800"
-            }`}
-            disabled={!isEditable}
-          />
-        </div>
-        <div className="flex-1">
-          <Popover
-            open={comboboxOpen}
-            onOpenChange={(open) => {
-              setComboboxOpen(open);
-              // Refresh options when dropdown is opened
-              if (open) {
-                execution?.execute();
-              }
-            }}
-          >
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                role="combobox"
-                aria-expanded={comboboxOpen}
-                className="w-full justify-between"
-              >
-                {execution?.isRunning ? (
-                  <div className="flex items-center">
-                    <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-blue-600 mr-2"></div>
-                    {
-                      dropdownState?.resolved?.options.find((option) => option.value === selected)
-                        ?.label
-                    }
-                  </div>
-                ) : selected ? (
-                  dropdownState?.resolved?.options.find((option) => option.value === selected)
-                    ?.label
-                ) : (
-                  "Select option..."
-                )}
-                <ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="p-0 w-[--radix-popover-trigger-width]">
-              <Command>
-                <CommandInput placeholder="Search options..." />
-                <CommandList>
-                  <CommandEmpty>No option found.</CommandEmpty>
-                  <CommandGroup>
-                    {dropdownState?.resolved?.options.map((option) => (
-                      <CommandItem
-                        key={option.value}
-                        value={option.value}
-                        onSelect={(currentValue) => {
-                          setSelected(currentValue === selected ? "" : currentValue);
-                          onValueUpdate(currentValue === selected ? "" : currentValue);
-                          setComboboxOpen(false);
-                        }}
-                      >
-                        <CheckIcon
-                          className={cn(
-                            "mr-2 h-4 w-4",
-                            selected === option.value ? "opacity-100" : "opacity-0",
-                          )}
-                        />
-                        {option.label}
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                </CommandList>
-              </Command>
-            </PopoverContent>
-          </Popover>
+          <div className="flex-1">
+            <Input
+              placeholder="Template variable name"
+              value={name}
+              onChange={(e) => onNameUpdate(e.target.value)}
+              style={{ fontFamily: "monospace" }}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              className={`bg-default-100 ${
+                hasNameError
+                  ? "border-red-400 dark:border-red-400 focus:ring-red-500"
+                  : "border-blue-200 dark:border-blue-800"
+              }`}
+              disabled={!isEditable}
+            />
+          </div>
+          <div className="flex-1">
+            <Popover
+              open={comboboxOpen}
+              onOpenChange={(open) => {
+                setComboboxOpen(open);
+                // Refresh options when dropdown is opened
+                if (open) {
+                  execution?.execute();
+                }
+              }}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={comboboxOpen}
+                  className="w-full justify-between"
+                >
+                  {execution?.isRunning ? (
+                    <div className="flex items-center">
+                      <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-300 border-t-blue-600 mr-2"></div>
+                      {
+                        dropdownState?.resolved?.options.find((option) => option.value === selected)
+                          ?.label
+                      }
+                    </div>
+                  ) : selected ? (
+                    dropdownState?.resolved?.options.find((option) => option.value === selected)
+                      ?.label
+                  ) : (
+                    "Select option..."
+                  )}
+                  <ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="p-0 w-[--radix-popover-trigger-width]">
+                <Command>
+                  <CommandInput placeholder="Search options..." />
+                  <CommandList>
+                    <CommandEmpty>No option found.</CommandEmpty>
+                    <CommandGroup>
+                      {dropdownState?.resolved?.options.map((option) => (
+                        <CommandItem
+                          key={option.value}
+                          value={option.value}
+                          onSelect={(currentValue) => {
+                            setSelected(currentValue === selected ? "" : currentValue);
+                            onValueUpdate(currentValue === selected ? "" : currentValue);
+                            setComboboxOpen(false);
+                          }}
+                        >
+                          <CheckIcon
+                            className={cn(
+                              "mr-2 h-4 w-4",
+                              selected === option.value ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                          {option.label}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
         </div>
       </div>
       {isOpen && (

--- a/src/components/runbooks/editor/blocks/Env/index.tsx
+++ b/src/components/runbooks/editor/blocks/Env/index.tsx
@@ -28,7 +28,9 @@ const Env = ({ name = "", value = "", onUpdate, isEditable }: EnvProps) => {
       delay={1000}
       className="outline-none"
     >
-      <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-green-50 to-emerald-50 dark:from-slate-800 dark:to-green-950 rounded-lg p-3 border border-green-200 dark:border-green-900 shadow-sm hover:shadow-md transition-all duration-200">
+      <div className="flex flex-col w-full bg-gradient-to-r from-green-50 to-emerald-50 dark:from-slate-800 dark:to-green-950 rounded-lg p-3 border border-green-200 dark:border-green-900 shadow-sm hover:shadow-md transition-all duration-200">
+        <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">env</span>
+        <div className="flex flex-row items-center space-x-3">
         <div className="flex items-center">
           <Button isIconOnly variant="light" className="bg-green-100 dark:bg-green-800 text-green-600 dark:text-green-300">
             <VariableIcon className="h-4 w-4" />
@@ -61,6 +63,7 @@ const Env = ({ name = "", value = "", onUpdate, isEditable }: EnvProps) => {
             className="flex-1 border-green-200 dark:border-green-800 focus:ring-green-500"
             disabled={!isEditable}
           />
+        </div>
         </div>
       </div>
     </Tooltip>

--- a/src/components/runbooks/editor/blocks/LocalVar/index.tsx
+++ b/src/components/runbooks/editor/blocks/LocalVar/index.tsx
@@ -25,47 +25,50 @@ const LocalVar = (props: LocalVarProps) => {
   }, [props.name]);
 
   return (
-    <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-purple-50 to-indigo-50 dark:from-slate-800 dark:to-purple-950 rounded-lg p-3 border border-purple-200 dark:border-purple-900 shadow-sm hover:shadow-md transition-all duration-200">
-      <div className="flex items-center">
-        <Button
-          isIconOnly
-          variant="light"
-          className="bg-purple-100 dark:bg-purple-800 text-purple-600 dark:text-purple-300"
-        >
-          <CloudOffIcon className="h-4 w-4" />
-        </Button>
+    <div className="flex flex-col w-full bg-gradient-to-r from-purple-50 to-indigo-50 dark:from-slate-800 dark:to-purple-950 rounded-lg p-3 border border-purple-200 dark:border-purple-900 shadow-sm hover:shadow-md transition-all duration-200">
+      <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">local-var</span>
+      <div className="flex flex-row items-center space-x-3">
+        <div className="flex items-center">
+          <Button
+            isIconOnly
+            variant="light"
+            className="bg-purple-100 dark:bg-purple-800 text-purple-600 dark:text-purple-300"
+          >
+            <CloudOffIcon className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <Input
+          placeholder="Name (shared)"
+          value={props.name}
+          onValueChange={props.onNameUpdate}
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck="false"
+          className={`flex-1 ${
+            hasNameError
+              ? "border-red-400 dark:border-red-400 focus:ring-red-500"
+              : "border-purple-200 dark:border-purple-800 focus:ring-purple-500"
+          }`}
+          disabled={!props.isEditable}
+          isInvalid={hasNameError}
+          errorMessage={"Variable names can only contain letters, numbers, and underscores"}
+        />
+
+        <Input
+          placeholder="Value (private and ephemeral - only stored on your device)"
+          value={value}
+          onValueChange={setValue}
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck="false"
+          className="flex-1 border-purple-200 dark:border-purple-800 focus:ring-purple-500"
+          disabled={!props.isEditable}
+          type="password"
+        />
       </div>
-
-      <Input
-        placeholder="Name (shared)"
-        value={props.name}
-        onValueChange={props.onNameUpdate}
-        autoComplete="off"
-        autoCapitalize="off"
-        autoCorrect="off"
-        spellCheck="false"
-        className={`flex-1 ${
-          hasNameError
-            ? "border-red-400 dark:border-red-400 focus:ring-red-500"
-            : "border-purple-200 dark:border-purple-800 focus:ring-purple-500"
-        }`}
-        disabled={!props.isEditable}
-        isInvalid={hasNameError}
-        errorMessage={"Variable names can only contain letters, numbers, and underscores"}
-      />
-
-      <Input
-        placeholder="Value (private and ephemeral - only stored on your device)"
-        value={value}
-        onValueChange={setValue}
-        autoComplete="off"
-        autoCapitalize="off"
-        autoCorrect="off"
-        spellCheck="false"
-        className="flex-1 border-purple-200 dark:border-purple-800 focus:ring-purple-500"
-        disabled={!props.isEditable}
-        type="password"
-      />
     </div>
   );
 };

--- a/src/components/runbooks/editor/blocks/Var/index.tsx
+++ b/src/components/runbooks/editor/blocks/Var/index.tsx
@@ -30,47 +30,50 @@ const Var = ({ name = "", value = "", onUpdate, isEditable }: VarProps) => {
   };
 
   return (
-    <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-green-50 to-emerald-50 dark:from-slate-800 dark:to-emerald-950 rounded-lg p-3 border border-green-200 dark:border-green-900 shadow-sm hover:shadow-md transition-all duration-200">
-      <div className="flex items-center">
-        <Button
-          isIconOnly
-          variant="light"
-          className="bg-green-100 dark:bg-green-800 text-green-600 dark:text-green-300"
-        >
-          <TextCursorInputIcon className="h-4 w-4" />
-        </Button>
-      </div>
+    <div className="flex flex-col w-full bg-gradient-to-r from-green-50 to-emerald-50 dark:from-slate-800 dark:to-emerald-950 rounded-lg p-3 border border-green-200 dark:border-green-900 shadow-sm hover:shadow-md transition-all duration-200">
+      <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">var</span>
+      <div className="flex flex-row items-center space-x-3">
+        <div className="flex items-center">
+          <Button
+            isIconOnly
+            variant="light"
+            className="bg-green-100 dark:bg-green-800 text-green-600 dark:text-green-300"
+          >
+            <TextCursorInputIcon className="h-4 w-4" />
+          </Button>
+        </div>
 
-      <Input
-        placeholder="Name"
-        value={name}
-        onChange={handleKeyChange}
-        autoComplete="off"
-        autoCapitalize="off"
-        autoCorrect="off"
-        spellCheck="false"
-        className={`flex-1 ${
-          hasNameError
-            ? "border-red-400 dark:border-red-400 focus:ring-red-500"
-            : "border-green-200 dark:border-green-800 focus:ring-green-500"
-        }`}
-        disabled={!isEditable}
-        isInvalid={hasNameError}
-        errorMessage={"Variable names can only contain letters, numbers, and underscores"}
-      />
-
-      <div className="flex-1">
         <Input
-          placeholder="Value"
-          value={value}
-          onChange={handleValueChange}
+          placeholder="Name"
+          value={name}
+          onChange={handleKeyChange}
           autoComplete="off"
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck="false"
-          className="flex-1 border-green-200 dark:border-green-800 focus:ring-green-500"
+          className={`flex-1 ${
+            hasNameError
+              ? "border-red-400 dark:border-red-400 focus:ring-red-500"
+              : "border-green-200 dark:border-green-800 focus:ring-green-500"
+          }`}
           disabled={!isEditable}
+          isInvalid={hasNameError}
+          errorMessage={"Variable names can only contain letters, numbers, and underscores"}
         />
+
+        <div className="flex-1">
+          <Input
+            placeholder="Value"
+            value={value}
+            onChange={handleValueChange}
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck="false"
+            className="flex-1 border-green-200 dark:border-green-800 focus:ring-green-500"
+            disabled={!isEditable}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/runbooks/editor/blocks/VarDisplay/index.tsx
+++ b/src/components/runbooks/editor/blocks/VarDisplay/index.tsx
@@ -32,36 +32,39 @@ const VarDisplay = (props: VarDisplayProps) => {
       delay={1000}
       className="outline-none"
     >
-      <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-slate-800 dark:to-indigo-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200">
-        <div className="flex items-center">
-          <Button
-            isIconOnly
-            variant="light"
-            className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
-          >
-            <EyeIcon className="h-4 w-4" />
-          </Button>
-        </div>
+      <div className="flex flex-col w-full bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-slate-800 dark:to-indigo-950 rounded-lg p-3 border border-blue-200 dark:border-blue-900 shadow-sm hover:shadow-md transition-all duration-200">
+        <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">var_display</span>
+        <div className="flex flex-row items-center space-x-3">
+          <div className="flex items-center">
+            <Button
+              isIconOnly
+              variant="light"
+              className="bg-blue-100 dark:bg-blue-800 text-blue-600 dark:text-blue-300"
+            >
+              <EyeIcon className="h-4 w-4" />
+            </Button>
+          </div>
 
-        <div className="flex-1">
-          <Input
-            placeholder="Variable name"
-            value={props.name}
-            onValueChange={props.onUpdate}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck="false"
-            className="flex-1 border-blue-200 dark:border-blue-800 focus:ring-blue-500"
-            disabled={!props.isEditable}
-          />
-        </div>
+          <div className="flex-1">
+            <Input
+              placeholder="Variable name"
+              value={props.name}
+              onValueChange={props.onUpdate}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck="false"
+              className="flex-1 border-blue-200 dark:border-blue-800 focus:ring-blue-500"
+              disabled={!props.isEditable}
+            />
+          </div>
 
-        <div className="flex-1 bg-white dark:bg-slate-900 rounded-md px-4 py-2 border border-blue-200 dark:border-blue-800 font-mono text-sm min-h-[2rem] max-h-[6rem] overflow-auto">
-          <div className="w-full transition-opacity duration-200">
-            {value.unwrapOr(
-              <span className="italic text-gray-500 dark:text-gray-400">(empty)</span>,
-            )}
+          <div className="flex-1 bg-white dark:bg-slate-900 rounded-md px-4 py-2 border border-blue-200 dark:border-blue-800 font-mono text-sm min-h-[2rem] max-h-[6rem] overflow-auto">
+            <div className="w-full transition-opacity duration-200">
+              {value.unwrapOr(
+                <span className="italic text-gray-500 dark:text-gray-400">(empty)</span>,
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/runbooks/editor/blocks/ssh/SshConnect.tsx
+++ b/src/components/runbooks/editor/blocks/ssh/SshConnect.tsx
@@ -21,29 +21,32 @@ const SshConnect = ({ userHost, onUserHostChange, isEditable }: SshConnectProps)
       delay={1000}
       className="outline-none"
     >
-      <div className="flex flex-row items-center space-x-3 w-full bg-gradient-to-r from-slate-50 to-gray-50 dark:from-slate-800 dark:to-slate-900 rounded-lg p-3 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200">
-        <div className="flex items-center">
-          <Button
-            isIconOnly
-            variant="light"
-            className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300"
-          >
-            <GlobeIcon className="h-4 w-4" />
-          </Button>
-        </div>
+      <div className="flex flex-col w-full bg-gradient-to-r from-slate-50 to-gray-50 dark:from-slate-800 dark:to-slate-900 rounded-lg p-3 border border-slate-200 dark:border-slate-700 shadow-sm hover:shadow-md transition-all duration-200">
+        <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 mb-2">ssh-connect</span>
+        <div className="flex flex-row items-center space-x-3">
+          <div className="flex items-center">
+            <Button
+              isIconOnly
+              variant="light"
+              className="bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300"
+            >
+              <GlobeIcon className="h-4 w-4" />
+            </Button>
+          </div>
 
-        <div className="flex-1">
-          <Input
-            placeholder="myserver or user@host:port"
-            value={userHost}
-            autoComplete="off"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck="false"
-            className="flex-1 border-slate-200 dark:border-slate-700 focus:ring-slate-500"
-            onValueChange={onUserHostChange}
-            disabled={!isEditable}
-          />
+          <div className="flex-1">
+            <Input
+              placeholder="myserver or user@host:port"
+              value={userHost}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck="false"
+              className="flex-1 border-slate-200 dark:border-slate-700 focus:ring-slate-500"
+              onValueChange={onUserHostChange}
+              disabled={!isEditable}
+            />
+          </div>
         </div>
       </div>
     </Tooltip>

--- a/src/lib/blocks/common/Block.tsx
+++ b/src/lib/blocks/common/Block.tsx
@@ -63,7 +63,7 @@ export default function Block({
     <Card className={cn("w-full !max-w-full !outline-none", className)} shadow="sm" ref={ref}>
       <CardHeader className="p-3 gap-2 bg-default-50 flex flex-col items-start justify-start z-auto">
         <div className="flex flex-row justify-between w-full">
-          <span className="text-default-700 font-semibold text-xs">{type}</span>
+          <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500">{type.toLowerCase()}</span>
           <div className="flex items-center gap-2">
             {topRightElement}
             {hasDependency && parentBlock && (


### PR DESCRIPTION
Apply consistent styling to block type labels across all blocks:
- Use 10px monospace font with subdued gray color
- Display type names in lowercase
- Match the styling introduced in SubRunbook block
