### PR TITLE
style: Split settings pane into multiple views

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -26,8 +26,6 @@ import {
   Slider,
   Tabs,
   Tab,
-  Navbar,
-  NavbarContent,
 } from "@heroui/react";
 import { Settings } from "@/state/settings";
 import { KVStore } from "@/state/kv";


### PR DESCRIPTION
Our settings pane is getting a little large; this PR splits it into several smaller pages.

<img width="1123" height="812" alt="image" src="https://github.com/user-attachments/assets/3e52c4d7-5872-44cf-b8c0-1a01af7d2055" />

<img width="1123" height="812" alt="image" src="https://github.com/user-attachments/assets/f14dbdfe-a9e9-40c7-b555-d67798a19831" />

The pane selector always stays visible, giving a subtle background blur when content overlaps.

<img width="1123" height="812" alt="image" src="https://github.com/user-attachments/assets/4b6e0ad2-0473-42bc-85d1-4fb0ff50c0fd" />

<img width="1123" height="812" alt="image" src="https://github.com/user-attachments/assets/8c8db8a2-0684-42ec-b4da-3b069a55430a" />
