### PR TITLE
fix: "push before joining" errors in Phoenix channels

### DIFF
--- a/src/lib/phoenix_provider.ts
+++ b/src/lib/phoenix_provider.ts
@@ -180,13 +180,6 @@ export class PhoenixSynchronizer extends Emittery {
   private async doResync(): Promise<boolean> {
     if (this.isShutdown) return false;
 
-    try {
-      await this.channel.ensureJoined();
-    } catch (err: any) {
-      this.logger.error("Failed to ensure joined on doc channel", JSON.stringify(err));
-      return false;
-    }
-
     // Step 1: Get our state vector and send it to the server in exchange for
     // the server's state vector
     const stateVector = Y.encodeStateVector(this.doc);
@@ -281,14 +274,7 @@ export default class PhoenixProvider extends PhoenixSynchronizer {
     if (origin === this || !this.channel) return;
 
     if (this.connected) {
-      this.channel
-        .ensureJoined()
-        .then(() => {
-          this.channel.push("client_update", update.buffer);
-        })
-        .catch((err) => {
-          console.error("FAILED to ensure joined", err);
-        });
+      this.channel.push("client_update", update.buffer);
     }
   }
 
@@ -298,12 +284,10 @@ export default class PhoenixProvider extends PhoenixSynchronizer {
 
     const changedClients = added.concat(updated).concat(removed);
     if (this.connected) {
-      this.channel.ensureJoined().then(() => {
-        this.channel.push(
-          "client_awareness",
-          awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients).buffer,
-        );
-      });
+      this.channel.push(
+        "client_awareness",
+        awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients).buffer,
+      );
     }
   }
 

--- a/src/server_notification_manager.ts
+++ b/src/server_notification_manager.ts
@@ -64,8 +64,6 @@ export default class ServerNotificationManager extends Emittery {
   }
 
   public async startNotifications() {
-    await this.channel.ensureJoined();
-
     // Subscribe is idempotent on the server, so we can just call it with all the runbook IDs
     const runbookIds = await Runbook.allIdsInAllWorkspaces();
     // TODO: replace this with a proper org model one day


### PR DESCRIPTION
`WrappedChannel.push()` now automatically calls `ensureJoined()` before pushing, eliminating race conditions where pushes could occur before the channel was ready.

Changes:

- `push()` defers the actual push until `ensureJoined()` resolves
- `WrappedPush` now wraps a `Promise<Push>` instead of `Push`
- Reset `joinPromise` in `handleNewSocket()` to fix stale promise after socket reconnection
- Remove redundant `ensureJoined()` calls from consumers
