### PR TITLE
fix: ssh username resolution

### DIFF
--- a/crates/atuin-desktop-runtime/src/ssh/session.rs
+++ b/crates/atuin-desktop-runtime/src/ssh/session.rs
@@ -317,7 +317,7 @@ impl Session {
     }
 
     /// Resolve SSH configuration for a host using ~/.ssh/config with russh-config
-    fn resolve_ssh_config(host: &str) -> SshConfig {
+    pub fn resolve_ssh_config(host: &str) -> SshConfig {
         // Parse the input to extract user, hostname, and port
         let (input_user, hostname, input_port) = Self::parse_host_string(host);
 


### PR DESCRIPTION
When the SSH config file specified a username, but the SSH block did not, we incorrectly prioritised the system username over the config file