### PR TITLE
Pass runbook_id to AI block operations

### DIFF
--- a/src/components/runbooks/editor/AIGeneratePopup.tsx
+++ b/src/components/runbooks/editor/AIGeneratePopup.tsx
@@ -1,5 +1,10 @@
 import { useCallback } from "react";
-import { generateBlocks, BlockSpec, AIFeatureDisabledError } from "@/lib/ai/block_generator";
+import {
+  generateBlocks,
+  BlockSpec,
+  AIFeatureDisabledError,
+  AIQuotaExceededError,
+} from "@/lib/ai/block_generator";
 import { AIPopupBase } from "./ui/AIPopupBase";
 import track_event from "@/tracking";
 
@@ -7,6 +12,7 @@ interface EditorContext {
   documentMarkdown?: string;
   currentBlockId: string;
   currentBlockIndex: number;
+  runbookId?: string;
 }
 
 interface AIGeneratePopupProps {
@@ -38,6 +44,7 @@ export function AIGeneratePopup({
           prompt,
           documentMarkdown: context?.documentMarkdown,
           insertAfterIndex: context?.currentBlockIndex,
+          runbookId: context?.runbookId,
         });
 
         if (result.blocks.length > 0) {
@@ -55,6 +62,10 @@ export function AIGeneratePopup({
       } catch (error) {
         if (error instanceof AIFeatureDisabledError) {
           track_event("runbooks.ai.generate_feature_disabled", {
+            prompt_length: prompt.length,
+          });
+        } else if (error instanceof AIQuotaExceededError) {
+          track_event("runbooks.ai.generate_quota_exceeded", {
             prompt_length: prompt.length,
           });
         } else {

--- a/src/components/runbooks/editor/ui/AIPopup.tsx
+++ b/src/components/runbooks/editor/ui/AIPopup.tsx
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 import { AIPopupBase } from "./AIPopupBase";
-import { AIFeatureDisabledError } from "@/lib/ai/block_editor";
+import { AIFeatureDisabledError, AIQuotaExceededError } from "@/lib/ai/block_editor";
 import track_event from "@/tracking";
 
 interface EditorContext {
   documentMarkdown?: string;
   currentBlockId: string;
   currentBlockIndex: number;
+  runbookId?: string;
 }
 
 interface AIPopupProps {
@@ -151,6 +152,7 @@ export default function AIPopup({
           currentBlock,
           documentMarkdown: context?.documentMarkdown,
           blockIndex: context?.currentBlockIndex,
+          runbookId: context?.runbookId,
         });
 
         if (result.updatedBlock) {
@@ -164,6 +166,11 @@ export default function AIPopup({
       } catch (error) {
         if (error instanceof AIFeatureDisabledError) {
           track_event("runbooks.ai.edit_feature_disabled", {
+            blockType,
+            blockId: currentBlock.id,
+          });
+        } else if (error instanceof AIQuotaExceededError) {
+          track_event("runbooks.ai.edit_quota_exceeded", {
             blockType,
             blockId: currentBlock.id,
           });

--- a/src/components/runbooks/editor/ui/AIPopupBase.tsx
+++ b/src/components/runbooks/editor/ui/AIPopupBase.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { Button, Textarea, Spinner } from "@heroui/react";
+import { Button, Textarea, Spinner, addToast } from "@heroui/react";
 import { SparklesIcon, ArrowRightIcon } from "lucide-react";
+import { AIQuotaExceededError } from "@/api/ai";
 
 interface AIPopupBaseProps {
   isVisible: boolean;
@@ -46,8 +47,17 @@ export function AIPopupBase({
       setPrompt("");
       onClose();
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Request failed";
-      setError(errorMessage);
+      if (err instanceof AIQuotaExceededError) {
+        addToast({
+          title: "Quota exceeded",
+          description: "AI quota exceeded",
+          color: "danger",
+        });
+        onClose();
+      } else {
+        const errorMessage = err instanceof Error ? err.message : "Request failed";
+        setError(errorMessage);
+      }
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/ai/block_editor.ts
+++ b/src/lib/ai/block_editor.ts
@@ -1,10 +1,16 @@
-import { generateOrEditBlock, AIFeatureDisabledError, AIGenerationError } from "@/api/ai";
+import {
+  generateOrEditBlock,
+  AIFeatureDisabledError,
+  AIGenerationError,
+  AIQuotaExceededError,
+} from "@/api/ai";
 
 export interface EditBlockRequest {
   prompt: string;
   currentBlock: any;
   documentMarkdown?: string;
   blockIndex?: number;
+  runbookId?: string;
 }
 
 export interface EditBlockResponse {
@@ -12,7 +18,7 @@ export interface EditBlockResponse {
   explanation?: string;
 }
 
-export { AIFeatureDisabledError, AIGenerationError };
+export { AIFeatureDisabledError, AIGenerationError, AIQuotaExceededError };
 
 export async function editBlock(request: EditBlockRequest): Promise<EditBlockResponse> {
   const response = await generateOrEditBlock({
@@ -22,6 +28,7 @@ export async function editBlock(request: EditBlockRequest): Promise<EditBlockRes
     block_type: request.currentBlock?.type,
     document_markdown: request.documentMarkdown,
     block_index: request.blockIndex,
+    runbook_id: request.runbookId,
   });
 
   // Always use the original block's ID, never trust AI-provided ones

--- a/src/lib/ai/block_generator.ts
+++ b/src/lib/ai/block_generator.ts
@@ -1,4 +1,9 @@
-import { generateOrEditBlock, AIFeatureDisabledError, AIGenerationError } from "@/api/ai";
+import {
+  generateOrEditBlock,
+  AIFeatureDisabledError,
+  AIGenerationError,
+  AIQuotaExceededError,
+} from "@/api/ai";
 import { uuidv7 } from "uuidv7";
 import DevConsole from "../dev/dev_console";
 
@@ -14,6 +19,7 @@ export interface GenerateBlocksRequest {
   documentMarkdown?: string;
   insertAfterIndex?: number;
   insertBeforeIndex?: number;
+  runbookId?: string;
 }
 
 export interface GenerateBlocksResponse {
@@ -21,7 +27,7 @@ export interface GenerateBlocksResponse {
   explanation?: string;
 }
 
-export { AIFeatureDisabledError, AIGenerationError };
+export { AIFeatureDisabledError, AIGenerationError, AIQuotaExceededError };
 
 export async function generateBlocks(
   request: GenerateBlocksRequest
@@ -33,6 +39,7 @@ export async function generateBlocks(
     document_markdown: request.documentMarkdown,
     insert_after_index: request.insertAfterIndex,
     insert_before_index: request.insertBeforeIndex,
+    runbook_id: request.runbookId,
   });
 
   // Always generate our own ID, don't trust AI-provided ones


### PR DESCRIPTION
## Change Summary
Add runbook_id as a parameter through the AI block generation and editing flow, enabling the backend to maintain context about which runbook these operations are being performed within.

## Motivation and details
The AI block operations (generation and editing) now pass the runbook ID to the backend API. This allows the backend to have full context about which runbook a block operation belongs to, improving traceability and enabling more contextual AI responses.

## Tasks
- [x] Reviewed changes for correctness
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle