### PR TITLE
fix: incorrect terminal size over ssh

### DIFF
--- a/crates/atuin-desktop-runtime/src/ssh/session.rs
+++ b/crates/atuin-desktop-runtime/src/ssh/session.rs
@@ -967,8 +967,8 @@ impl Session {
 
                     resize = resize_stream.recv() => {
                         match resize {
-                            Some((width, height)) => {
-                                let _ = channel.window_change(width as u32, height as u32, 0, 0).await;
+                            Some((rows, cols)) => {
+                                let _ = channel.window_change(cols as u32, rows as u32, 0, 0).await;
                             }
                             None => {
                                 tracing::debug!("SSH resize stream closed");

--- a/src/lib/blocks/terminal/components/terminal.tsx
+++ b/src/lib/blocks/terminal/components/terminal.tsx
@@ -125,7 +125,6 @@ const TerminalComponent = ({
         terminalRef.current.appendChild(terminalData.terminal.element);
       }
 
-      // Initial fit
       if (terminalData.fitAddon) {
         terminalData.fitAddon.fit();
       }


### PR DESCRIPTION
Over SSH, we mixed up the terminal dimensions and resized incorrectly. Fix it!

## Tasks
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
