### PR TITLE
fix: allow escape key in vim mode CodeMirror editors

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -213,8 +213,10 @@ window.addEventListener(
   "keydown",
   (event) => {
     const blocknoteBlock = (event.target as Element).closest(".bn-block");
+    const codemirrorEditor = (event.target as Element).closest(".cm-editor");
 
-    if (blocknoteBlock && event.key === "Escape") {
+    // Allow Escape to propagate to CodeMirror editors (needed for vim mode)
+    if (blocknoteBlock && event.key === "Escape" && !codemirrorEditor) {
       event.preventDefault();
       event.stopPropagation();
     }


### PR DESCRIPTION
## Change Summary

Allow Escape key to propagate to CodeMirror editors when vim mode is enabled. Previously, a global event listener was blocking all Escape keys within BlockNote blocks to prevent a collapse bug, which also prevented vim mode from functioning (Escape should switch from insert to normal mode).

## Motivation and Details

The fix adds a check to exclude CodeMirror editors (`.cm-editor`) from the escape key blocking. This allows vim mode to receive the escape key for mode switching while still protecting other BlockNote content from the original collapse bug.

## Tasks

- [x] No TS-RS binding changes needed
- [x] No documentation changes needed
- [x] Ready for review