### PR TITLE
Remove non-functional SSH host export from sub-runbooks

### DIFF
--- a/src/components/runbooks/editor/blocks/SubRunbook/SubRunbook.tsx
+++ b/src/components/runbooks/editor/blocks/SubRunbook/SubRunbook.tsx
@@ -135,7 +135,6 @@ interface ContextExportSettings {
   exportEnv: boolean;
   exportVars: boolean;
   exportCwd: boolean;
-  exportSshHost: boolean;
 }
 
 interface SubRunbookProps {
@@ -680,17 +679,16 @@ const SubRunbook = ({
                   isDisabled={!isEditable}
                   onPress={() => {
                     const allEnabled = exportSettings.exportEnv && exportSettings.exportVars &&
-                                       exportSettings.exportCwd && exportSettings.exportSshHost;
+                                       exportSettings.exportCwd;
                     onExportSettingsChange({
                       exportEnv: !allEnabled,
                       exportVars: !allEnabled,
                       exportCwd: !allEnabled,
-                      exportSshHost: !allEnabled,
                     });
                   }}
                 >
                   {exportSettings.exportEnv && exportSettings.exportVars &&
-                   exportSettings.exportCwd && exportSettings.exportSshHost
+                   exportSettings.exportCwd
                     ? "Disable All Exports"
                     : "Export All Context"}
                 </Button>
@@ -750,23 +748,6 @@ const SubRunbook = ({
                   isDisabled={!isEditable}
                 />
               </div>
-
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    SSH host
-                  </span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    Use sub-runbook&apos;s SSH connection
-                  </span>
-                </div>
-                <Switch
-                  size="sm"
-                  isSelected={exportSettings.exportSshHost}
-                  onValueChange={(value) => onExportSettingsChange({ exportSshHost: value })}
-                  isDisabled={!isEditable}
-                />
-              </div>
             </div>
           </ModalBody>
         </ModalContent>
@@ -799,7 +780,6 @@ export default createReactBlockSpec(
       exportEnv: { default: false },     // Export env vars to parent runbook
       exportVars: { default: false },    // Export variables to parent runbook
       exportCwd: { default: false },     // Export working directory to parent runbook
-      exportSshHost: { default: false }, // Export SSH host to parent runbook
     },
     content: "none",
   },
@@ -807,7 +787,7 @@ export default createReactBlockSpec(
     toExternalHTML: ({ block }) => {
       const propMatter = exportPropMatter("sub-runbook", block.props, [
         "name", "runbookId", "runbookUri", "runbookPath", "runbookName",
-        "exportEnv", "exportVars", "exportCwd", "exportSshHost"
+        "exportEnv", "exportVars", "exportCwd"
       ]);
       return (
         <div>
@@ -859,7 +839,6 @@ export default createReactBlockSpec(
             ...(settings.exportEnv !== undefined && { exportEnv: settings.exportEnv }),
             ...(settings.exportVars !== undefined && { exportVars: settings.exportVars }),
             ...(settings.exportCwd !== undefined && { exportCwd: settings.exportCwd }),
-            ...(settings.exportSshHost !== undefined && { exportSshHost: settings.exportSshHost }),
           },
         });
       };
@@ -875,7 +854,6 @@ export default createReactBlockSpec(
             exportEnv: block.props.exportEnv,
             exportVars: block.props.exportVars,
             exportCwd: block.props.exportCwd,
-            exportSshHost: block.props.exportSshHost,
           }}
           isEditable={editor.isEditable}
           onRunbookSelect={onRunbookSelect}


### PR DESCRIPTION
## Change Summary

Remove the non-functional SSH host export option from sub-runbooks. 

## Motivation and details

There's still some work needed to get sub-runbook ssh sessions shareable. I'll revisit in the future, if there's demand

## Tasks

- [x] Rust code compiles (verified with `cargo check`)
- [x] TypeScript compiles (verified with `tsc --noEmit`)
- [ ] Regenerated TS-RS bindings (not needed - no `ts(export)` structs changed)
- [ ] Updated the documentation in `docs/` (not needed - internal implementation detail)
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle