### PR TITLE
feat: add copy deep link command to command menu

### DIFF
--- a/src/lib/commands/registry.ts
+++ b/src/lib/commands/registry.ts
@@ -1,5 +1,6 @@
 import { Command, CommandImplementation, CommandSearchResult, CommandContext } from "./types";
 import { useStore } from "@/state/store";
+import { TabUri } from "@/state/store/ui_state";
 import {
   FolderPlus,
   Download,
@@ -298,18 +299,16 @@ export function registerBuiltinCommands(): void {
       const state = useStore.getState();
       const currentTab = state.tabs.find((tab) => tab.id === state.currentTabId);
       if (!currentTab) return false;
-      return currentTab.url.startsWith("/runbook/");
+      return new TabUri(currentTab.url).isRunbook();
     },
     handler: async () => {
       const state = useStore.getState();
       const currentTab = state.tabs.find((tab) => tab.id === state.currentTabId);
-      if (!currentTab || !currentTab.url.startsWith("/runbook/")) {
-        console.error("Not in a runbook");
-        return;
-      }
-      const runbookId = currentTab.url.split("/").pop();
+      if (!currentTab) return;
+      const tabUri = new TabUri(currentTab.url);
+      const runbookId = tabUri.getRunbookId();
       if (!runbookId) {
-        console.error("Could not get runbook ID");
+        console.error("Not in a runbook");
         return;
       }
       const deepLink = `atuin://runbook/${runbookId}`;


### PR DESCRIPTION
## Change Summary
Adds a new "Copy Deep Link" command to the command palette that generates and copies an `atuin://runbook/:runbookId` deep link to the clipboard.

## Motivation and details
Users can now easily share deep links to runbooks via the command menu. The command is only enabled when viewing a runbook and provides toast feedback for copy success or failure, following existing UI patterns in the codebase.

## Tasks
- [x] No TS-RS bindings changed
- [x] No application behavior documentation needed
- [x] Ready for review