### PR TITLE
fix: PWD=/ when launched from finder

### DIFF
--- a/crates/atuin-desktop-runtime/src/context/resolution.rs
+++ b/crates/atuin-desktop-runtime/src/context/resolution.rs
@@ -339,9 +339,9 @@ impl ContextResolver {
 fn default_cwd() -> String {
     // Check for PWD env var first (set by shell, reflects current directory)
     // This allows CLI tools to inherit the user's current working directory
-    // Falls back to home directory for desktop app / GUI contexts
+    // Skip "/" as it's not useful - macOS sets PWD="/" when launching GUI apps from Finder
     if let Ok(pwd) = std::env::var("PWD") {
-        if !pwd.is_empty() {
+        if !pwd.is_empty() && pwd != "/" {
             return pwd;
         }
     }


### PR DESCRIPTION
Launching from finder caused pwd=/ on macos, leading to weird terminal + script behaviour

I'm unsure how widespread this is, but we likely didn't catch it sooner because most of our runbooks have directory blocks or we launch the app from the terminal

I don't think this happened on Linux

## Tasks
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
