### PR TITLE
fix: workspace collapse unreliability

### DIFF
--- a/src/state/store/ui_state.ts
+++ b/src/state/store/ui_state.ts
@@ -483,12 +483,13 @@ export const createUiState: StateCreator<AtuinUiState> = (set, get, _store): Atu
   },
   toggleWorkspaceVisibility: (workspaceId: string) => {
     set((state) => {
-      if (state.hiddenWorkspaces[workspaceId]) {
-        delete state.hiddenWorkspaces[workspaceId];
+      const newHiddenWorkspaces = { ...state.hiddenWorkspaces };
+      if (newHiddenWorkspaces[workspaceId]) {
+        delete newHiddenWorkspaces[workspaceId];
       } else {
-        state.hiddenWorkspaces[workspaceId] = true;
+        newHiddenWorkspaces[workspaceId] = true;
       }
-      return state;
+      return { hiddenWorkspaces: newHiddenWorkspaces };
     });
   },
   // updateFolderState: (workspaceId: string, state: Record<string, boolean>) => {


### PR DESCRIPTION
Fix workspace collapse chevron not responding by returning new state object instead of mutating in place

## Tasks
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
