### PR TITLE
feat: add link preview blocks for GitHub, GitLab, and Codeberg

### DIFF
--- a/src/components/runbooks/editor/create_editor.ts
+++ b/src/components/runbooks/editor/create_editor.ts
@@ -18,7 +18,16 @@ import Postgres from "./blocks/Postgres/Postgres";
 import MySQL from "./blocks/MySQL/MySQL";
 import Clickhouse from "./blocks/Clickhouse/Clickhouse";
 import { HttpBlockSpec } from "@/lib/blocks/http";
+import { GitHubPreviewBlockSpec } from "@/lib/blocks/github-preview";
+import { CodebergPreviewBlockSpec } from "@/lib/blocks/codeberg-preview";
+import { GitLabPreviewBlockSpec } from "@/lib/blocks/gitlab-preview";
 import { LocalDirectoryBlockSpec } from "@/lib/blocks/localdirectory";
+import { linkPreviewPasteHandler } from "@/lib/blocks/link-preview";
+
+// Import to register link preview handlers (side effect)
+import "@/lib/blocks/github-preview/paste-handler";
+import "@/lib/blocks/codeberg-preview/paste-handler";
+import "@/lib/blocks/gitlab-preview/paste-handler";
 import Script from "./blocks/Script/Script";
 import SshConnect from "./blocks/ssh/SshConnect";
 import HostSelect from "./blocks/Host";
@@ -80,6 +89,11 @@ export const schema = BlockNoteSchema.create({
 
     // Workflow control
     pause: Pause(),
+
+    // Link Previews
+    githubPreview: GitHubPreviewBlockSpec(),
+    codebergPreview: CodebergPreviewBlockSpec(),
+    gitlabPreview: GitLabPreviewBlockSpec(),
   },
   inlineContentSpecs: {
     // Adds all default inline content.
@@ -102,6 +116,7 @@ export function createBasicEditor(content: any) {
 export function createLocalOnlyEditor(content: any) {
   let editor = BlockNoteEditor.create({
     schema,
+    pasteHandler: linkPreviewPasteHandler,
     _tiptapOptions: {
       editorProps: {
         scrollThreshold: 200,
@@ -126,6 +141,7 @@ export function createCollaborativeEditor(
   presenceColor = presenceColor || randomColor();
   let editor = BlockNoteEditor.create({
     schema,
+    pasteHandler: linkPreviewPasteHandler,
     _tiptapOptions: {
       editorProps: {
         scrollThreshold: 200,

--- a/src/lib/blocks/codeberg-preview/api.ts
+++ b/src/lib/blocks/codeberg-preview/api.ts
@@ -1,0 +1,198 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import { extensionToLanguage } from "../shared/language-detection";
+
+export interface CodebergRepoData {
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  stars_count: number;
+  forks_count: number;
+  language: string | null;
+  owner: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface CodebergPRData {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  merged: boolean;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface CodebergIssueData {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  comments: number;
+  labels: Array<{
+    name: string;
+    color: string;
+  }>;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface CodebergCodeData {
+  content: string;
+  filePath: string;
+  language: string;
+  lineStart?: number;
+  lineEnd?: number;
+  html_url: string;
+}
+
+export type CodebergData = CodebergRepoData | CodebergPRData | CodebergIssueData | CodebergCodeData;
+
+const CODEBERG_API_BASE = "https://codeberg.org/api/v1";
+const RAW_CODEBERG_BASE = "https://codeberg.org";
+
+export async function fetchCodebergRepoData(owner: string, repo: string): Promise<CodebergRepoData> {
+  const response = await fetch(`${CODEBERG_API_BASE}/repos/${owner}/${repo}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch repo: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    name: data.name,
+    full_name: data.full_name,
+    description: data.description,
+    html_url: data.html_url,
+    stars_count: data.stars_count,
+    forks_count: data.forks_count,
+    language: data.language,
+    owner: {
+      login: data.owner.login,
+      avatar_url: data.owner.avatar_url,
+    },
+  };
+}
+
+export async function fetchCodebergPRData(owner: string, repo: string, prNumber: number): Promise<CodebergPRData> {
+  const response = await fetch(`${CODEBERG_API_BASE}/repos/${owner}/${repo}/pulls/${prNumber}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PR: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    number: data.number,
+    title: data.title,
+    body: data.body,
+    html_url: data.html_url,
+    state: data.state,
+    merged: data.merged,
+    additions: data.additions || 0,
+    deletions: data.deletions || 0,
+    changed_files: data.changed_files || 0,
+    user: {
+      login: data.user.login,
+      avatar_url: data.user.avatar_url,
+    },
+  };
+}
+
+export async function fetchCodebergIssueData(owner: string, repo: string, issueNumber: number): Promise<CodebergIssueData> {
+  const response = await fetch(`${CODEBERG_API_BASE}/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch issue: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    number: data.number,
+    title: data.title,
+    body: data.body,
+    html_url: data.html_url,
+    state: data.state,
+    comments: data.comments || 0,
+    labels: (data.labels || []).map((l: any) => ({ name: l.name, color: l.color })),
+    user: {
+      login: data.user.login,
+      avatar_url: data.user.avatar_url,
+    },
+  };
+}
+
+export async function fetchCodebergCodeData(
+  owner: string,
+  repo: string,
+  branch: string,
+  filePath: string,
+  lineStart?: number,
+  lineEnd?: number,
+): Promise<CodebergCodeData> {
+  const response = await fetch(`${RAW_CODEBERG_BASE}/${owner}/${repo}/raw/branch/${branch}/${filePath}`, {
+    headers: {
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch code: ${response.status} ${response.statusText}`);
+  }
+
+  const fullContent = await response.text();
+
+  let content = fullContent;
+  if (lineStart !== undefined) {
+    const lines = fullContent.split("\n");
+    const end = lineEnd ?? lineStart;
+    content = lines.slice(lineStart - 1, end).join("\n");
+  }
+
+  const extension = filePath.split(".").pop() || "";
+  const language = extensionToLanguage(extension);
+
+  let html_url = `https://codeberg.org/${owner}/${repo}/src/branch/${branch}/${filePath}`;
+  if (lineStart !== undefined) {
+    html_url += `#L${lineStart}`;
+    if (lineEnd !== undefined && lineEnd !== lineStart) {
+      html_url += `-L${lineEnd}`;
+    }
+  }
+
+  return {
+    content,
+    filePath,
+    language,
+    lineStart,
+    lineEnd,
+    html_url,
+  };
+}
+

--- a/src/lib/blocks/codeberg-preview/components/CodePreview.tsx
+++ b/src/lib/blocks/codeberg-preview/components/CodePreview.tsx
@@ -1,0 +1,84 @@
+import { Card, CardBody, CardHeader } from "@heroui/react";
+import { FileCodeIcon, ExternalLinkIcon } from "lucide-react";
+import { Highlight } from "prism-react-renderer";
+import Prism from "prismjs";
+import type { CodebergCodeData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+import { useStore } from "@/state/store";
+import { themes } from "prism-react-renderer";
+
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-yaml";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-toml";
+
+interface CodePreviewProps {
+  data: CodebergCodeData;
+}
+
+export default function CodePreview({ data }: CodePreviewProps) {
+  const colorMode = useStore((state) => state.functionalColorMode);
+
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const theme = colorMode === "dark" ? themes.vsDark : themes.vsLight;
+  const startLineNumber = data.lineStart ?? 1;
+
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardHeader
+        className="p-3 bg-default-50 cursor-pointer hover:bg-default-100 transition-colors"
+        onClick={handleClick}
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <FileCodeIcon size={14} className="text-default-400" />
+          <span className="font-mono text-default-600">{data.filePath}</span>
+          {data.lineStart && (
+            <span className="text-default-400">
+              L{data.lineStart}
+              {data.lineEnd && data.lineEnd !== data.lineStart && `-L${data.lineEnd}`}
+            </span>
+          )}
+          <ExternalLinkIcon size={14} className="text-default-400 ml-auto" />
+        </div>
+      </CardHeader>
+      <CardBody className="p-0 overflow-auto max-h-80">
+        <Highlight
+          theme={theme}
+          code={data.content}
+          // @ts-ignore
+          prism={Prism}
+          language={data.language}
+        >
+          {({ style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              style={{ ...style, margin: 0, padding: "12px" }}
+              className="text-sm font-mono overflow-x-auto"
+            >
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  <span className="text-default-400 select-none inline-block w-10 text-right pr-4">
+                    {startLineNumber + i}
+                  </span>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )}
+        </Highlight>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/codeberg-preview/components/CodebergPreview.tsx
+++ b/src/lib/blocks/codeberg-preview/components/CodebergPreview.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Card, CardBody, Button } from "@heroui/react";
+import { RefreshCwIcon, AlertCircleIcon } from "lucide-react";
+import LoadingState from "./LoadingState";
+import RepoPreview from "./RepoPreview";
+import PRPreview from "./PRPreview";
+import IssuePreview from "./IssuePreview";
+import CodePreview from "./CodePreview";
+import {
+  fetchCodebergRepoData,
+  fetchCodebergPRData,
+  fetchCodebergIssueData,
+  fetchCodebergCodeData,
+  CodebergRepoData,
+  CodebergPRData,
+  CodebergIssueData,
+  CodebergCodeData,
+} from "../api";
+import type { CodebergBlockProps } from "../schema";
+
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+interface CodebergPreviewProps {
+  props: CodebergBlockProps;
+  updateProps: (updates: Partial<CodebergBlockProps>) => void;
+}
+
+export default function CodebergPreview({ props, updateProps }: CodebergPreviewProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<CodebergRepoData | CodebergPRData | CodebergIssueData | CodebergCodeData | null>(null);
+  const mountedRef = useRef(true);
+
+  const isCacheValid = useCallback(() => {
+    if (!props.cachedAt || !props.cachedData || props.cachedData === "{}") {
+      return false;
+    }
+    const cachedTime = new Date(props.cachedAt).getTime();
+    return Date.now() - cachedTime < CACHE_DURATION_MS;
+  }, [props.cachedAt, props.cachedData]);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      let result: CodebergRepoData | CodebergPRData | CodebergIssueData | CodebergCodeData;
+
+      switch (props.urlType) {
+        case "repo":
+          result = await fetchCodebergRepoData(props.owner, props.repo);
+          break;
+        case "pr":
+          result = await fetchCodebergPRData(props.owner, props.repo, parseInt(props.prNumber, 10));
+          break;
+        case "issue":
+          result = await fetchCodebergIssueData(props.owner, props.repo, parseInt(props.issueNumber, 10));
+          break;
+        case "code":
+          result = await fetchCodebergCodeData(
+            props.owner,
+            props.repo,
+            props.branch,
+            props.filePath,
+            props.lineStart ? parseInt(props.lineStart, 10) : undefined,
+            props.lineEnd ? parseInt(props.lineEnd, 10) : undefined,
+          );
+          break;
+        default:
+          throw new Error(`Unknown URL type: ${props.urlType}`);
+      }
+
+      if (!mountedRef.current) return;
+
+      setData(result);
+
+      updateProps({
+        cachedData: JSON.stringify(result),
+        cachedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to fetch data");
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [props.owner, props.repo, props.urlType, props.prNumber, props.issueNumber, props.branch, props.filePath, props.lineStart, props.lineEnd, updateProps]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (isCacheValid()) {
+      try {
+        setData(JSON.parse(props.cachedData));
+        return;
+      } catch {
+        // Cache is invalid, will fetch fresh
+      }
+    }
+
+    if (props.owner && props.repo && props.urlType) {
+      fetchData();
+    }
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [props.owner, props.repo, props.urlType, props.prNumber, props.issueNumber, props.branch, props.filePath, isCacheValid, props.cachedData, fetchData]);
+
+  const handleRefresh = () => {
+    fetchData();
+  };
+
+  if (loading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return (
+      <Card className="w-full" shadow="sm">
+        <CardBody className="p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-danger">
+              <AlertCircleIcon size={18} />
+              <span className="text-sm">{error}</span>
+            </div>
+            <Button size="sm" variant="flat" onPress={handleRefresh} startContent={<RefreshCwIcon size={14} />}>
+              Retry
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return <LoadingState />;
+  }
+
+  return (
+    <div className="relative group">
+      {props.urlType === "repo" && <RepoPreview data={data as CodebergRepoData} />}
+      {props.urlType === "pr" && <PRPreview data={data as CodebergPRData} />}
+      {props.urlType === "issue" && <IssuePreview data={data as CodebergIssueData} />}
+      {props.urlType === "code" && <CodePreview data={data as CodebergCodeData} />}
+
+      <Button
+        size="sm"
+        variant="flat"
+        isIconOnly
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+        onPress={handleRefresh}
+      >
+        <RefreshCwIcon size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/blocks/codeberg-preview/components/IssuePreview.tsx
+++ b/src/lib/blocks/codeberg-preview/components/IssuePreview.tsx
@@ -1,0 +1,97 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { CircleDotIcon, ExternalLinkIcon, CheckCircleIcon } from "lucide-react";
+import type { CodebergIssueData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface IssuePreviewProps {
+  data: CodebergIssueData;
+}
+
+// Normalize color to ensure no duplicate # prefix
+function normalizeColor(color: string): string {
+  return color.replace(/^#/, "");
+}
+
+export default function IssuePreview({ data }: IssuePreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" => {
+    return data.state === "open" ? "success" : "secondary";
+  };
+
+  const getStatusIcon = () => {
+    return data.state === "open" ? <CircleDotIcon size={14} /> : <CheckCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    return data.state === "open" ? "Open" : "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.user.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">#{data.number}</span>
+                <span className="text-xs text-default-400">by {data.user.login}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.body && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.body}</p>
+        )}
+
+        <div className="flex items-center gap-3 flex-wrap">
+          {data.labels.map((label) => {
+            const color = normalizeColor(label.color);
+            return (
+              <Chip
+                key={label.name}
+                size="sm"
+                variant="flat"
+                style={{
+                  backgroundColor: `#${color}20`,
+                  color: `#${color}`,
+                  borderColor: `#${color}40`,
+                }}
+                className="border"
+              >
+                {label.name}
+              </Chip>
+            );
+          })}
+          {data.comments > 0 && (
+            <span className="text-xs text-default-400">
+              {data.comments} comment{data.comments !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/codeberg-preview/components/LoadingState.tsx
+++ b/src/lib/blocks/codeberg-preview/components/LoadingState.tsx
@@ -1,0 +1,19 @@
+import { Card, CardBody, Skeleton } from "@heroui/react";
+
+export default function LoadingState() {
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-10 h-10 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-3/4 rounded" />
+            <Skeleton className="h-3 w-1/2 rounded" />
+          </div>
+        </div>
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-2/3 rounded" />
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/codeberg-preview/components/PRPreview.tsx
+++ b/src/lib/blocks/codeberg-preview/components/PRPreview.tsx
@@ -1,0 +1,78 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { GitPullRequestIcon, ExternalLinkIcon, GitMergeIcon, XCircleIcon } from "lucide-react";
+import type { CodebergPRData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface PRPreviewProps {
+  data: CodebergPRData;
+}
+
+export default function PRPreview({ data }: PRPreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" | "danger" => {
+    if (data.merged) return "secondary";
+    if (data.state === "open") return "success";
+    return "danger";
+  };
+
+  const getStatusIcon = () => {
+    if (data.merged) return <GitMergeIcon size={14} />;
+    if (data.state === "open") return <GitPullRequestIcon size={14} />;
+    return <XCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    if (data.merged) return "Merged";
+    if (data.state === "open") return "Open";
+    return "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.user.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">#{data.number}</span>
+                <span className="text-xs text-default-400">by {data.user.login}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.body && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.body}</p>
+        )}
+
+        <div className="flex items-center gap-4 text-sm">
+          <span className="text-success-500">+{data.additions}</span>
+          <span className="text-danger-500">-{data.deletions}</span>
+          <span className="text-default-400">{data.changed_files} files</span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/codeberg-preview/components/RepoPreview.tsx
+++ b/src/lib/blocks/codeberg-preview/components/RepoPreview.tsx
@@ -1,0 +1,67 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { StarIcon, GitForkIcon, ExternalLinkIcon } from "lucide-react";
+import type { CodebergRepoData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface RepoPreviewProps {
+  data: CodebergRepoData;
+}
+
+export default function RepoPreview({ data }: RepoPreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Avatar src={data.owner.avatar_url} size="sm" className="flex-shrink-0" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-sm truncate">{data.full_name}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              {data.language && (
+                <Chip size="sm" variant="flat" className="mt-1">
+                  {data.language}
+                </Chip>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {data.description && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.description}</p>
+        )}
+
+        <div className="flex items-center gap-4 text-sm text-default-400">
+          <span className="flex items-center gap-1">
+            <StarIcon size={14} />
+            {formatNumber(data.stars_count)}
+          </span>
+          <span className="flex items-center gap-1">
+            <GitForkIcon size={14} />
+            {formatNumber(data.forks_count)}
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1000000) {
+    return (num / 1000000).toFixed(1) + "M";
+  }
+  if (num >= 1000) {
+    return (num / 1000).toFixed(1) + "k";
+  }
+  return num.toString();
+}

--- a/src/lib/blocks/codeberg-preview/index.ts
+++ b/src/lib/blocks/codeberg-preview/index.ts
@@ -1,0 +1,5 @@
+// Codeberg Preview Block - link preview for Codeberg URLs
+export { default as CodebergPreviewBlockSpec } from "./spec";
+export { CODEBERG_PREVIEW_BLOCK_SCHEMA, type CodebergBlockProps } from "./schema";
+export { isCodebergUrl, parseCodebergUrl } from "./url-parser";
+export type { ParsedCodebergUrl, CodebergUrlType } from "./url-parser";

--- a/src/lib/blocks/codeberg-preview/paste-handler.ts
+++ b/src/lib/blocks/codeberg-preview/paste-handler.ts
@@ -1,0 +1,52 @@
+import { linkPreviewRegistry, type LinkPreviewHandler } from "../link-preview";
+import { isCodebergUrl, parseCodebergUrl } from "./url-parser";
+import type { CodebergBlockProps } from "./schema";
+
+/**
+ * Codeberg link preview handler.
+ * Converts Codeberg URLs into rich preview blocks.
+ */
+export const codebergLinkPreviewHandler: LinkPreviewHandler = {
+  id: "codeberg",
+
+  matches(url: string): boolean {
+    return isCodebergUrl(url);
+  },
+
+  createBlock(url: string): { type: string; props: Record<string, string> } | null {
+    const parsed = parseCodebergUrl(url);
+    if (!parsed) {
+      return null;
+    }
+
+    const props: Partial<CodebergBlockProps> = {
+      url,
+      urlType: parsed.type,
+      owner: parsed.owner,
+      repo: parsed.repo,
+    };
+
+    if (parsed.type === "pr" && parsed.prNumber !== undefined) {
+      props.prNumber = parsed.prNumber.toString();
+    }
+
+    if (parsed.type === "issue" && parsed.issueNumber !== undefined) {
+      props.issueNumber = parsed.issueNumber.toString();
+    }
+
+    if (parsed.type === "code") {
+      if (parsed.branch) props.branch = parsed.branch;
+      if (parsed.filePath) props.filePath = parsed.filePath;
+      if (parsed.lineStart !== undefined) props.lineStart = parsed.lineStart.toString();
+      if (parsed.lineEnd !== undefined) props.lineEnd = parsed.lineEnd.toString();
+    }
+
+    return {
+      type: "codebergPreview",
+      props: props as Record<string, string>,
+    };
+  },
+};
+
+// Register the Codeberg handler
+linkPreviewRegistry.register(codebergLinkPreviewHandler);

--- a/src/lib/blocks/codeberg-preview/schema.ts
+++ b/src/lib/blocks/codeberg-preview/schema.ts
@@ -1,0 +1,33 @@
+export const CODEBERG_PREVIEW_BLOCK_SCHEMA = {
+  type: "codebergPreview",
+  propSchema: {
+    url: { default: "" },
+    urlType: { default: "" }, // "repo" | "pr" | "issue" | "code"
+    owner: { default: "" },
+    repo: { default: "" },
+    prNumber: { default: "" },
+    issueNumber: { default: "" },
+    branch: { default: "" },
+    filePath: { default: "" },
+    lineStart: { default: "" },
+    lineEnd: { default: "" },
+    cachedData: { default: "{}" },
+    cachedAt: { default: "" },
+  },
+  content: "none",
+} as const;
+
+export type CodebergBlockProps = {
+  url: string;
+  urlType: string;
+  owner: string;
+  repo: string;
+  prNumber: string;
+  issueNumber: string;
+  branch: string;
+  filePath: string;
+  lineStart: string;
+  lineEnd: string;
+  cachedData: string;
+  cachedAt: string;
+};

--- a/src/lib/blocks/codeberg-preview/spec.tsx
+++ b/src/lib/blocks/codeberg-preview/spec.tsx
@@ -1,0 +1,23 @@
+// @ts-ignore
+import { createReactBlockSpec } from "@blocknote/react";
+
+import CodebergPreview from "./components/CodebergPreview";
+import { CODEBERG_PREVIEW_BLOCK_SCHEMA, CodebergBlockProps } from "./schema";
+
+export default createReactBlockSpec(CODEBERG_PREVIEW_BLOCK_SCHEMA, {
+  // @ts-ignore
+  render: ({ block, editor }) => {
+    const updateProps = (updates: Partial<CodebergBlockProps>) => {
+      editor.updateBlock(block, {
+        // @ts-ignore
+        props: { ...block.props, ...updates },
+      });
+    };
+
+    return (
+      <div contentEditable={false} className="w-full">
+        <CodebergPreview props={block.props} updateProps={updateProps} />
+      </div>
+    );
+  },
+});

--- a/src/lib/blocks/codeberg-preview/url-parser.ts
+++ b/src/lib/blocks/codeberg-preview/url-parser.ts
@@ -1,0 +1,96 @@
+export type CodebergUrlType = "repo" | "pr" | "issue" | "code";
+
+export interface ParsedCodebergUrl {
+  type: CodebergUrlType;
+  owner: string;
+  repo: string;
+  prNumber?: number;
+  issueNumber?: number;
+  branch?: string;
+  filePath?: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+const CODEBERG_URL_REGEX = /^https?:\/\/(www\.)?codeberg\.org\/([^/]+)\/([^/]+)(\/.*)?$/;
+
+export function isCodebergUrl(text: string): boolean {
+  return CODEBERG_URL_REGEX.test(text.trim());
+}
+
+export function parseCodebergUrl(url: string): ParsedCodebergUrl | null {
+  const trimmedUrl = url.trim();
+  const match = trimmedUrl.match(CODEBERG_URL_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  const owner = match[2];
+  const repo = match[3];
+  const rest = match[4] || "";
+
+  // Check for PR URL: /pulls/{number}
+  const prMatch = rest.match(/^\/pulls\/(\d+)/);
+  if (prMatch) {
+    return {
+      type: "pr",
+      owner,
+      repo,
+      prNumber: parseInt(prMatch[1], 10),
+    };
+  }
+
+  // Check for issue URL: /issues/{number}
+  const issueMatch = rest.match(/^\/issues\/(\d+)/);
+  if (issueMatch) {
+    return {
+      type: "issue",
+      owner,
+      repo,
+      issueNumber: parseInt(issueMatch[1], 10),
+    };
+  }
+
+  // Check for code URL: /src/branch/{branch}/{path} or /src/commit/{hash}/{path}
+  // Line numbers: #L{start}-L{end} or #L{start}
+  const codeMatch = rest.match(/^\/src\/(?:branch|commit|tag)\/([^/]+)\/(.+?)(?:#L(\d+)(?:-L(\d+))?)?$/);
+  if (codeMatch) {
+    const result: ParsedCodebergUrl = {
+      type: "code",
+      owner,
+      repo,
+      branch: codeMatch[1],
+      filePath: codeMatch[2],
+    };
+
+    if (codeMatch[3]) {
+      result.lineStart = parseInt(codeMatch[3], 10);
+    }
+    if (codeMatch[4]) {
+      result.lineEnd = parseInt(codeMatch[4], 10);
+    }
+
+    return result;
+  }
+
+  // Default to repo URL
+  const isRepoPath =
+    rest === "" ||
+    rest === "/" ||
+    rest.match(/^\/(src|commits|branches|tags|releases|issues|pulls|activity|settings)?(\/?.*)$/);
+
+  if (isRepoPath) {
+    return {
+      type: "repo",
+      owner,
+      repo,
+    };
+  }
+
+  return {
+    type: "repo",
+    owner,
+    repo,
+  };
+}

--- a/src/lib/blocks/github-preview/api.ts
+++ b/src/lib/blocks/github-preview/api.ts
@@ -1,0 +1,160 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import { extensionToLanguage } from "../shared/language-detection";
+
+export interface RepoData {
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  forks_count: number;
+  language: string | null;
+  owner: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface PRData {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  merged: boolean;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface IssueData {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  comments: number;
+  labels: Array<{
+    name: string;
+    color: string;
+  }>;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+}
+
+export interface CodeData {
+  content: string;
+  filePath: string;
+  language: string;
+  lineStart?: number;
+  lineEnd?: number;
+  html_url: string;
+}
+
+export type GitHubData = RepoData | PRData | IssueData | CodeData;
+
+const GITHUB_API_BASE = "https://api.github.com";
+const RAW_GITHUB_BASE = "https://raw.githubusercontent.com";
+
+export async function fetchRepoData(owner: string, repo: string): Promise<RepoData> {
+  const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}`, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch repo: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchPRData(owner: string, repo: string, prNumber: number): Promise<PRData> {
+  const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}/pulls/${prNumber}`, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PR: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchIssueData(owner: string, repo: string, issueNumber: number): Promise<IssueData> {
+  const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch issue: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchCodeData(
+  owner: string,
+  repo: string,
+  branch: string,
+  filePath: string,
+  lineStart?: number,
+  lineEnd?: number,
+): Promise<CodeData> {
+  const response = await fetch(`${RAW_GITHUB_BASE}/${owner}/${repo}/${branch}/${filePath}`, {
+    headers: {
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch code: ${response.status} ${response.statusText}`);
+  }
+
+  const fullContent = await response.text();
+
+  // Extract lines if specified
+  let content = fullContent;
+  if (lineStart !== undefined) {
+    const lines = fullContent.split("\n");
+    const end = lineEnd ?? lineStart;
+    content = lines.slice(lineStart - 1, end).join("\n");
+  }
+
+  // Detect language from file extension
+  const extension = filePath.split(".").pop() || "";
+  const language = extensionToLanguage(extension);
+
+  // Build GitHub URL with line references
+  let html_url = `https://github.com/${owner}/${repo}/blob/${branch}/${filePath}`;
+  if (lineStart !== undefined) {
+    html_url += `#L${lineStart}`;
+    if (lineEnd !== undefined && lineEnd !== lineStart) {
+      html_url += `-L${lineEnd}`;
+    }
+  }
+
+  return {
+    content,
+    filePath,
+    language,
+    lineStart,
+    lineEnd,
+    html_url,
+  };
+}
+

--- a/src/lib/blocks/github-preview/components/CodePreview.tsx
+++ b/src/lib/blocks/github-preview/components/CodePreview.tsx
@@ -1,0 +1,87 @@
+import { Card, CardBody, CardHeader } from "@heroui/react";
+import { FileCodeIcon, ExternalLinkIcon } from "lucide-react";
+import { Highlight } from "prism-react-renderer";
+import Prism from "prismjs";
+import type { CodeData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+import { useStore } from "@/state/store";
+import { themes } from "prism-react-renderer";
+
+// Load additional Prism languages
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-yaml";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-toml";
+
+interface CodePreviewProps {
+  data: CodeData;
+}
+
+export default function CodePreview({ data }: CodePreviewProps) {
+  const colorMode = useStore((state) => state.functionalColorMode);
+
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const theme = colorMode === "dark" ? themes.vsDark : themes.vsLight;
+
+  // Calculate starting line number for display
+  const startLineNumber = data.lineStart ?? 1;
+
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardHeader
+        className="p-3 bg-default-50 cursor-pointer hover:bg-default-100 transition-colors"
+        onClick={handleClick}
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <FileCodeIcon size={14} className="text-default-400" />
+          <span className="font-mono text-default-600">{data.filePath}</span>
+          {data.lineStart && (
+            <span className="text-default-400">
+              L{data.lineStart}
+              {data.lineEnd && data.lineEnd !== data.lineStart && `-L${data.lineEnd}`}
+            </span>
+          )}
+          <ExternalLinkIcon size={14} className="text-default-400 ml-auto" />
+        </div>
+      </CardHeader>
+      <CardBody className="p-0 overflow-auto max-h-80">
+        <Highlight
+          theme={theme}
+          code={data.content}
+          // @ts-ignore
+          prism={Prism}
+          language={data.language}
+        >
+          {({ style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              style={{ ...style, margin: 0, padding: "12px" }}
+              className="text-sm font-mono overflow-x-auto"
+            >
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  <span className="text-default-400 select-none inline-block w-10 text-right pr-4">
+                    {startLineNumber + i}
+                  </span>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )}
+        </Highlight>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/github-preview/components/GitHubPreview.tsx
+++ b/src/lib/blocks/github-preview/components/GitHubPreview.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Card, CardBody, Button } from "@heroui/react";
+import { RefreshCwIcon, AlertCircleIcon } from "lucide-react";
+import LoadingState from "./LoadingState";
+import RepoPreview from "./RepoPreview";
+import PRPreview from "./PRPreview";
+import IssuePreview from "./IssuePreview";
+import CodePreview from "./CodePreview";
+import { fetchRepoData, fetchPRData, fetchIssueData, fetchCodeData, RepoData, PRData, IssueData, CodeData } from "../api";
+import type { GitHubBlockProps } from "../schema";
+
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+interface GitHubPreviewProps {
+  props: GitHubBlockProps;
+  updateProps: (updates: Partial<GitHubBlockProps>) => void;
+}
+
+export default function GitHubPreview({ props, updateProps }: GitHubPreviewProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<RepoData | PRData | IssueData | CodeData | null>(null);
+  const mountedRef = useRef(true);
+
+  // Check if cache is still valid
+  const isCacheValid = useCallback(() => {
+    if (!props.cachedAt || !props.cachedData || props.cachedData === "{}") {
+      return false;
+    }
+    const cachedTime = new Date(props.cachedAt).getTime();
+    return Date.now() - cachedTime < CACHE_DURATION_MS;
+  }, [props.cachedAt, props.cachedData]);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      let result: RepoData | PRData | IssueData | CodeData;
+
+      switch (props.urlType) {
+        case "repo":
+          result = await fetchRepoData(props.owner, props.repo);
+          break;
+        case "pr":
+          result = await fetchPRData(props.owner, props.repo, parseInt(props.prNumber, 10));
+          break;
+        case "issue":
+          result = await fetchIssueData(props.owner, props.repo, parseInt(props.issueNumber, 10));
+          break;
+        case "code":
+          result = await fetchCodeData(
+            props.owner,
+            props.repo,
+            props.branch,
+            props.filePath,
+            props.lineStart ? parseInt(props.lineStart, 10) : undefined,
+            props.lineEnd ? parseInt(props.lineEnd, 10) : undefined,
+          );
+          break;
+        default:
+          throw new Error(`Unknown URL type: ${props.urlType}`);
+      }
+
+      if (!mountedRef.current) return;
+
+      setData(result);
+
+      // Cache the result
+      updateProps({
+        cachedData: JSON.stringify(result),
+        cachedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to fetch data");
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [props.owner, props.repo, props.urlType, props.prNumber, props.issueNumber, props.branch, props.filePath, props.lineStart, props.lineEnd, updateProps]);
+
+  // Load data from cache or fetch
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (isCacheValid()) {
+      try {
+        setData(JSON.parse(props.cachedData));
+        return;
+      } catch {
+        // Cache is invalid, will fetch fresh
+      }
+    }
+
+    if (props.owner && props.repo && props.urlType) {
+      fetchData();
+    }
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [props.owner, props.repo, props.urlType, props.prNumber, props.issueNumber, props.branch, props.filePath, isCacheValid, props.cachedData, fetchData]);
+
+  const handleRefresh = () => {
+    fetchData();
+  };
+
+  if (loading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return (
+      <Card className="w-full" shadow="sm">
+        <CardBody className="p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-danger">
+              <AlertCircleIcon size={18} />
+              <span className="text-sm">{error}</span>
+            </div>
+            <Button size="sm" variant="flat" onPress={handleRefresh} startContent={<RefreshCwIcon size={14} />}>
+              Retry
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return <LoadingState />;
+  }
+
+  return (
+    <div className="relative group">
+      {props.urlType === "repo" && <RepoPreview data={data as RepoData} />}
+      {props.urlType === "pr" && <PRPreview data={data as PRData} />}
+      {props.urlType === "issue" && <IssuePreview data={data as IssueData} />}
+      {props.urlType === "code" && <CodePreview data={data as CodeData} />}
+
+      {/* Refresh button - shows on hover */}
+      <Button
+        size="sm"
+        variant="flat"
+        isIconOnly
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+        onPress={handleRefresh}
+      >
+        <RefreshCwIcon size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/blocks/github-preview/components/IssuePreview.tsx
+++ b/src/lib/blocks/github-preview/components/IssuePreview.tsx
@@ -1,0 +1,97 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { CircleDotIcon, ExternalLinkIcon, CheckCircleIcon } from "lucide-react";
+import type { IssueData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface IssuePreviewProps {
+  data: IssueData;
+}
+
+// Normalize color to ensure no duplicate # prefix
+function normalizeColor(color: string): string {
+  return color.replace(/^#/, "");
+}
+
+export default function IssuePreview({ data }: IssuePreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" => {
+    return data.state === "open" ? "success" : "secondary";
+  };
+
+  const getStatusIcon = () => {
+    return data.state === "open" ? <CircleDotIcon size={14} /> : <CheckCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    return data.state === "open" ? "Open" : "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.user.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">#{data.number}</span>
+                <span className="text-xs text-default-400">by {data.user.login}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.body && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.body}</p>
+        )}
+
+        <div className="flex items-center gap-3 flex-wrap">
+          {data.labels.map((label) => {
+            const color = normalizeColor(label.color);
+            return (
+              <Chip
+                key={label.name}
+                size="sm"
+                variant="flat"
+                style={{
+                  backgroundColor: `#${color}20`,
+                  color: `#${color}`,
+                  borderColor: `#${color}40`,
+                }}
+                className="border"
+              >
+                {label.name}
+              </Chip>
+            );
+          })}
+          {data.comments > 0 && (
+            <span className="text-xs text-default-400">
+              {data.comments} comment{data.comments !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/github-preview/components/LoadingState.tsx
+++ b/src/lib/blocks/github-preview/components/LoadingState.tsx
@@ -1,0 +1,19 @@
+import { Card, CardBody, Skeleton } from "@heroui/react";
+
+export default function LoadingState() {
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-10 h-10 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-3/4 rounded" />
+            <Skeleton className="h-3 w-1/2 rounded" />
+          </div>
+        </div>
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-2/3 rounded" />
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/github-preview/components/PRPreview.tsx
+++ b/src/lib/blocks/github-preview/components/PRPreview.tsx
@@ -1,0 +1,78 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { GitPullRequestIcon, ExternalLinkIcon, GitMergeIcon, XCircleIcon } from "lucide-react";
+import type { PRData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface PRPreviewProps {
+  data: PRData;
+}
+
+export default function PRPreview({ data }: PRPreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" | "danger" => {
+    if (data.merged) return "secondary";
+    if (data.state === "open") return "success";
+    return "danger";
+  };
+
+  const getStatusIcon = () => {
+    if (data.merged) return <GitMergeIcon size={14} />;
+    if (data.state === "open") return <GitPullRequestIcon size={14} />;
+    return <XCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    if (data.merged) return "Merged";
+    if (data.state === "open") return "Open";
+    return "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.user.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">#{data.number}</span>
+                <span className="text-xs text-default-400">by {data.user.login}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.body && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.body}</p>
+        )}
+
+        <div className="flex items-center gap-4 text-sm">
+          <span className="text-success-500">+{data.additions}</span>
+          <span className="text-danger-500">-{data.deletions}</span>
+          <span className="text-default-400">{data.changed_files} files</span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/github-preview/components/RepoPreview.tsx
+++ b/src/lib/blocks/github-preview/components/RepoPreview.tsx
@@ -1,0 +1,67 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { StarIcon, GitForkIcon, ExternalLinkIcon } from "lucide-react";
+import type { RepoData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface RepoPreviewProps {
+  data: RepoData;
+}
+
+export default function RepoPreview({ data }: RepoPreviewProps) {
+  const handleClick = () => {
+    open(data.html_url);
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Avatar src={data.owner.avatar_url} size="sm" className="flex-shrink-0" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-sm truncate">{data.full_name}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              {data.language && (
+                <Chip size="sm" variant="flat" className="mt-1">
+                  {data.language}
+                </Chip>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {data.description && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.description}</p>
+        )}
+
+        <div className="flex items-center gap-4 text-sm text-default-400">
+          <span className="flex items-center gap-1">
+            <StarIcon size={14} />
+            {formatNumber(data.stargazers_count)}
+          </span>
+          <span className="flex items-center gap-1">
+            <GitForkIcon size={14} />
+            {formatNumber(data.forks_count)}
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1000000) {
+    return (num / 1000000).toFixed(1) + "M";
+  }
+  if (num >= 1000) {
+    return (num / 1000).toFixed(1) + "k";
+  }
+  return num.toString();
+}

--- a/src/lib/blocks/github-preview/index.ts
+++ b/src/lib/blocks/github-preview/index.ts
@@ -1,0 +1,6 @@
+// GitHub Preview Block - link preview for GitHub URLs
+export * from "./schema";
+export * from "./url-parser";
+export * from "./api";
+export * from "./paste-handler";
+export { default as GitHubPreviewBlockSpec } from "./spec";

--- a/src/lib/blocks/github-preview/paste-handler.ts
+++ b/src/lib/blocks/github-preview/paste-handler.ts
@@ -1,0 +1,52 @@
+import { linkPreviewRegistry, type LinkPreviewHandler } from "../link-preview";
+import { isGitHubUrl, parseGitHubUrl } from "./url-parser";
+import type { GitHubBlockProps } from "./schema";
+
+/**
+ * GitHub link preview handler.
+ * Converts GitHub URLs into rich preview blocks.
+ */
+export const githubLinkPreviewHandler: LinkPreviewHandler = {
+  id: "github",
+
+  matches(url: string): boolean {
+    return isGitHubUrl(url);
+  },
+
+  createBlock(url: string): { type: string; props: Record<string, string> } | null {
+    const parsed = parseGitHubUrl(url);
+    if (!parsed) {
+      return null;
+    }
+
+    const props: Partial<GitHubBlockProps> = {
+      url,
+      urlType: parsed.type,
+      owner: parsed.owner,
+      repo: parsed.repo,
+    };
+
+    if (parsed.type === "pr" && parsed.prNumber !== undefined) {
+      props.prNumber = parsed.prNumber.toString();
+    }
+
+    if (parsed.type === "issue" && parsed.issueNumber !== undefined) {
+      props.issueNumber = parsed.issueNumber.toString();
+    }
+
+    if (parsed.type === "code") {
+      if (parsed.branch) props.branch = parsed.branch;
+      if (parsed.filePath) props.filePath = parsed.filePath;
+      if (parsed.lineStart !== undefined) props.lineStart = parsed.lineStart.toString();
+      if (parsed.lineEnd !== undefined) props.lineEnd = parsed.lineEnd.toString();
+    }
+
+    return {
+      type: "githubPreview",
+      props: props as Record<string, string>,
+    };
+  },
+};
+
+// Register the GitHub handler
+linkPreviewRegistry.register(githubLinkPreviewHandler);

--- a/src/lib/blocks/github-preview/schema.ts
+++ b/src/lib/blocks/github-preview/schema.ts
@@ -1,0 +1,33 @@
+export const GITHUB_PREVIEW_BLOCK_SCHEMA = {
+  type: "githubPreview",
+  propSchema: {
+    url: { default: "" },
+    urlType: { default: "" }, // "repo" | "pr" | "issue" | "code"
+    owner: { default: "" },
+    repo: { default: "" },
+    prNumber: { default: "" },
+    issueNumber: { default: "" },
+    branch: { default: "" },
+    filePath: { default: "" },
+    lineStart: { default: "" },
+    lineEnd: { default: "" },
+    cachedData: { default: "{}" }, // JSON-stringified preview data
+    cachedAt: { default: "" }, // ISO timestamp for cache invalidation
+  },
+  content: "none",
+} as const;
+
+export type GitHubBlockProps = {
+  url: string;
+  urlType: string;
+  owner: string;
+  repo: string;
+  prNumber: string;
+  issueNumber: string;
+  branch: string;
+  filePath: string;
+  lineStart: string;
+  lineEnd: string;
+  cachedData: string;
+  cachedAt: string;
+};

--- a/src/lib/blocks/github-preview/spec.tsx
+++ b/src/lib/blocks/github-preview/spec.tsx
@@ -1,0 +1,23 @@
+// @ts-ignore
+import { createReactBlockSpec } from "@blocknote/react";
+
+import GitHubPreview from "./components/GitHubPreview";
+import { GITHUB_PREVIEW_BLOCK_SCHEMA, GitHubBlockProps } from "./schema";
+
+export default createReactBlockSpec(GITHUB_PREVIEW_BLOCK_SCHEMA, {
+  // @ts-ignore
+  render: ({ block, editor }) => {
+    const updateProps = (updates: Partial<GitHubBlockProps>) => {
+      editor.updateBlock(block, {
+        // @ts-ignore
+        props: { ...block.props, ...updates },
+      });
+    };
+
+    return (
+      <div contentEditable={false} className="w-full">
+        <GitHubPreview props={block.props} updateProps={updateProps} />
+      </div>
+    );
+  },
+});

--- a/src/lib/blocks/github-preview/url-parser.ts
+++ b/src/lib/blocks/github-preview/url-parser.ts
@@ -1,0 +1,82 @@
+export type GitHubUrlType = "repo" | "pr" | "issue" | "code";
+
+export interface ParsedGitHubUrl {
+  type: GitHubUrlType;
+  owner: string;
+  repo: string;
+  prNumber?: number;
+  issueNumber?: number;
+  branch?: string;
+  filePath?: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+const GITHUB_URL_REGEX = /^https?:\/\/(www\.)?github\.com\/([^/]+)\/([^/]+)(\/.*)?$/;
+
+export function isGitHubUrl(text: string): boolean {
+  return GITHUB_URL_REGEX.test(text.trim());
+}
+
+export function parseGitHubUrl(url: string): ParsedGitHubUrl | null {
+  const trimmedUrl = url.trim();
+  const match = trimmedUrl.match(GITHUB_URL_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  const owner = match[2];
+  const repo = match[3];
+  const rest = match[4] || "";
+
+  // Check for PR URL: /pull/{number}
+  const prMatch = rest.match(/^\/pull\/(\d+)/);
+  if (prMatch) {
+    return {
+      type: "pr",
+      owner,
+      repo,
+      prNumber: parseInt(prMatch[1], 10),
+    };
+  }
+
+  // Check for issue URL: /issues/{number}
+  const issueMatch = rest.match(/^\/issues\/(\d+)/);
+  if (issueMatch) {
+    return {
+      type: "issue",
+      owner,
+      repo,
+      issueNumber: parseInt(issueMatch[1], 10),
+    };
+  }
+
+  // Check for code URL: /blob/{branch}/{path}#L{start}-L{end}
+  const codeMatch = rest.match(/^\/blob\/([^/]+)\/(.+?)(?:#L(\d+)(?:-L(\d+))?)?$/);
+  if (codeMatch) {
+    const result: ParsedGitHubUrl = {
+      type: "code",
+      owner,
+      repo,
+      branch: codeMatch[1],
+      filePath: codeMatch[2],
+    };
+
+    if (codeMatch[3]) {
+      result.lineStart = parseInt(codeMatch[3], 10);
+    }
+    if (codeMatch[4]) {
+      result.lineEnd = parseInt(codeMatch[4], 10);
+    }
+
+    return result;
+  }
+
+  // Default to repo for any other path (tree, commits, branches, etc.)
+  return {
+    type: "repo",
+    owner,
+    repo,
+  };
+}

--- a/src/lib/blocks/gitlab-preview/api.ts
+++ b/src/lib/blocks/gitlab-preview/api.ts
@@ -1,0 +1,194 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import { extensionToLanguage } from "../shared/language-detection";
+
+export interface GitLabRepoData {
+  name: string;
+  path_with_namespace: string;
+  description: string | null;
+  web_url: string;
+  star_count: number;
+  forks_count: number;
+  // GitLab doesn't return primary language in project API
+  owner: {
+    username: string;
+    avatar_url: string;
+  };
+}
+
+export interface GitLabMRData {
+  iid: number;
+  title: string;
+  description: string | null;
+  web_url: string;
+  state: "opened" | "closed" | "merged";
+  author: {
+    username: string;
+    avatar_url: string;
+  };
+  // These require additional API call, may be null
+  changes_count?: string;
+}
+
+export interface GitLabIssueData {
+  iid: number;
+  title: string;
+  description: string | null;
+  web_url: string;
+  state: "opened" | "closed";
+  user_notes_count: number;
+  labels: string[];
+  author: {
+    username: string;
+    avatar_url: string;
+  };
+}
+
+export interface GitLabCodeData {
+  content: string;
+  filePath: string;
+  language: string;
+  lineStart?: number;
+  lineEnd?: number;
+  web_url: string;
+}
+
+export type GitLabData = GitLabRepoData | GitLabMRData | GitLabIssueData | GitLabCodeData;
+
+const GITLAB_API_BASE = "https://gitlab.com/api/v4";
+
+function encodeProjectPath(projectPath: string): string {
+  return encodeURIComponent(projectPath);
+}
+
+export async function fetchGitLabRepoData(projectPath: string): Promise<GitLabRepoData> {
+  const response = await fetch(`${GITLAB_API_BASE}/projects/${encodeProjectPath(projectPath)}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch project: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    name: data.name,
+    path_with_namespace: data.path_with_namespace,
+    description: data.description,
+    web_url: data.web_url,
+    star_count: data.star_count,
+    forks_count: data.forks_count,
+    owner: {
+      username: data.namespace?.name || data.path_with_namespace.split("/")[0],
+      avatar_url: data.avatar_url || data.namespace?.avatar_url || "",
+    },
+  };
+}
+
+export async function fetchGitLabMRData(projectPath: string, mrNumber: number): Promise<GitLabMRData> {
+  const response = await fetch(`${GITLAB_API_BASE}/projects/${encodeProjectPath(projectPath)}/merge_requests/${mrNumber}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch MR: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    iid: data.iid,
+    title: data.title,
+    description: data.description,
+    web_url: data.web_url,
+    state: data.state,
+    author: {
+      username: data.author.username,
+      avatar_url: data.author.avatar_url,
+    },
+    changes_count: data.changes_count,
+  };
+}
+
+export async function fetchGitLabIssueData(projectPath: string, issueNumber: number): Promise<GitLabIssueData> {
+  const response = await fetch(`${GITLAB_API_BASE}/projects/${encodeProjectPath(projectPath)}/issues/${issueNumber}`, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "Atuin-Desktop",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch issue: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    iid: data.iid,
+    title: data.title,
+    description: data.description,
+    web_url: data.web_url,
+    state: data.state,
+    user_notes_count: data.user_notes_count || 0,
+    labels: data.labels || [],
+    author: {
+      username: data.author.username,
+      avatar_url: data.author.avatar_url,
+    },
+  };
+}
+
+export async function fetchGitLabCodeData(
+  projectPath: string,
+  branch: string,
+  filePath: string,
+  lineStart?: number,
+  lineEnd?: number,
+): Promise<GitLabCodeData> {
+  const response = await fetch(
+    `${GITLAB_API_BASE}/projects/${encodeProjectPath(projectPath)}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${encodeURIComponent(branch)}`,
+    {
+      headers: {
+        "User-Agent": "Atuin-Desktop",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch code: ${response.status} ${response.statusText}`);
+  }
+
+  const fullContent = await response.text();
+
+  let content = fullContent;
+  if (lineStart !== undefined) {
+    const lines = fullContent.split("\n");
+    const end = lineEnd ?? lineStart;
+    content = lines.slice(lineStart - 1, end).join("\n");
+  }
+
+  const extension = filePath.split(".").pop() || "";
+  const language = extensionToLanguage(extension);
+
+  let web_url = `https://gitlab.com/${projectPath}/-/blob/${branch}/${filePath}`;
+  if (lineStart !== undefined) {
+    web_url += `#L${lineStart}`;
+    if (lineEnd !== undefined && lineEnd !== lineStart) {
+      web_url += `-${lineEnd}`;
+    }
+  }
+
+  return {
+    content,
+    filePath,
+    language,
+    lineStart,
+    lineEnd,
+    web_url,
+  };
+}
+

--- a/src/lib/blocks/gitlab-preview/components/CodePreview.tsx
+++ b/src/lib/blocks/gitlab-preview/components/CodePreview.tsx
@@ -1,0 +1,84 @@
+import { Card, CardBody, CardHeader } from "@heroui/react";
+import { FileCodeIcon, ExternalLinkIcon } from "lucide-react";
+import { Highlight } from "prism-react-renderer";
+import Prism from "prismjs";
+import type { GitLabCodeData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+import { useStore } from "@/state/store";
+import { themes } from "prism-react-renderer";
+
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-java";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-yaml";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-sql";
+import "prismjs/components/prism-toml";
+
+interface CodePreviewProps {
+  data: GitLabCodeData;
+}
+
+export default function CodePreview({ data }: CodePreviewProps) {
+  const colorMode = useStore((state) => state.functionalColorMode);
+
+  const handleClick = () => {
+    open(data.web_url);
+  };
+
+  const theme = colorMode === "dark" ? themes.vsDark : themes.vsLight;
+  const startLineNumber = data.lineStart ?? 1;
+
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardHeader
+        className="p-3 bg-default-50 cursor-pointer hover:bg-default-100 transition-colors"
+        onClick={handleClick}
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <FileCodeIcon size={14} className="text-default-400" />
+          <span className="font-mono text-default-600">{data.filePath}</span>
+          {data.lineStart && (
+            <span className="text-default-400">
+              L{data.lineStart}
+              {data.lineEnd && data.lineEnd !== data.lineStart && `-${data.lineEnd}`}
+            </span>
+          )}
+          <ExternalLinkIcon size={14} className="text-default-400 ml-auto" />
+        </div>
+      </CardHeader>
+      <CardBody className="p-0 overflow-auto max-h-80">
+        <Highlight
+          theme={theme}
+          code={data.content}
+          // @ts-ignore
+          prism={Prism}
+          language={data.language}
+        >
+          {({ style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              style={{ ...style, margin: 0, padding: "12px" }}
+              className="text-sm font-mono overflow-x-auto"
+            >
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  <span className="text-default-400 select-none inline-block w-10 text-right pr-4">
+                    {startLineNumber + i}
+                  </span>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )}
+        </Highlight>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/gitlab-preview/components/GitLabPreview.tsx
+++ b/src/lib/blocks/gitlab-preview/components/GitLabPreview.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Card, CardBody, Button } from "@heroui/react";
+import { RefreshCwIcon, AlertCircleIcon } from "lucide-react";
+import LoadingState from "./LoadingState";
+import RepoPreview from "./RepoPreview";
+import MRPreview from "./MRPreview";
+import IssuePreview from "./IssuePreview";
+import CodePreview from "./CodePreview";
+import {
+  fetchGitLabRepoData,
+  fetchGitLabMRData,
+  fetchGitLabIssueData,
+  fetchGitLabCodeData,
+  GitLabRepoData,
+  GitLabMRData,
+  GitLabIssueData,
+  GitLabCodeData,
+} from "../api";
+import type { GitLabBlockProps } from "../schema";
+
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+interface GitLabPreviewProps {
+  props: GitLabBlockProps;
+  updateProps: (updates: Partial<GitLabBlockProps>) => void;
+}
+
+export default function GitLabPreview({ props, updateProps }: GitLabPreviewProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<GitLabRepoData | GitLabMRData | GitLabIssueData | GitLabCodeData | null>(null);
+  const mountedRef = useRef(true);
+
+  const isCacheValid = useCallback(() => {
+    if (!props.cachedAt || !props.cachedData || props.cachedData === "{}") {
+      return false;
+    }
+    const cachedTime = new Date(props.cachedAt).getTime();
+    return Date.now() - cachedTime < CACHE_DURATION_MS;
+  }, [props.cachedAt, props.cachedData]);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      let result: GitLabRepoData | GitLabMRData | GitLabIssueData | GitLabCodeData;
+
+      switch (props.urlType) {
+        case "repo":
+          result = await fetchGitLabRepoData(props.projectPath);
+          break;
+        case "mr":
+          result = await fetchGitLabMRData(props.projectPath, parseInt(props.mrNumber, 10));
+          break;
+        case "issue":
+          result = await fetchGitLabIssueData(props.projectPath, parseInt(props.issueNumber, 10));
+          break;
+        case "code":
+          result = await fetchGitLabCodeData(
+            props.projectPath,
+            props.branch,
+            props.filePath,
+            props.lineStart ? parseInt(props.lineStart, 10) : undefined,
+            props.lineEnd ? parseInt(props.lineEnd, 10) : undefined,
+          );
+          break;
+        default:
+          throw new Error(`Unknown URL type: ${props.urlType}`);
+      }
+
+      if (!mountedRef.current) return;
+
+      setData(result);
+
+      updateProps({
+        cachedData: JSON.stringify(result),
+        cachedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to fetch data");
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [props.projectPath, props.urlType, props.mrNumber, props.issueNumber, props.branch, props.filePath, props.lineStart, props.lineEnd, updateProps]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (isCacheValid()) {
+      try {
+        setData(JSON.parse(props.cachedData));
+        return;
+      } catch {
+        // Cache is invalid, will fetch fresh
+      }
+    }
+
+    if (props.projectPath && props.urlType) {
+      fetchData();
+    }
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [props.projectPath, props.urlType, props.mrNumber, props.issueNumber, props.branch, props.filePath, isCacheValid, props.cachedData, fetchData]);
+
+  const handleRefresh = () => {
+    fetchData();
+  };
+
+  if (loading) {
+    return <LoadingState />;
+  }
+
+  if (error) {
+    return (
+      <Card className="w-full" shadow="sm">
+        <CardBody className="p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-danger">
+              <AlertCircleIcon size={18} />
+              <span className="text-sm">{error}</span>
+            </div>
+            <Button size="sm" variant="flat" onPress={handleRefresh} startContent={<RefreshCwIcon size={14} />}>
+              Retry
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return <LoadingState />;
+  }
+
+  return (
+    <div className="relative group">
+      {props.urlType === "repo" && <RepoPreview data={data as GitLabRepoData} />}
+      {props.urlType === "mr" && <MRPreview data={data as GitLabMRData} />}
+      {props.urlType === "issue" && <IssuePreview data={data as GitLabIssueData} />}
+      {props.urlType === "code" && <CodePreview data={data as GitLabCodeData} />}
+
+      <Button
+        size="sm"
+        variant="flat"
+        isIconOnly
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+        onPress={handleRefresh}
+      >
+        <RefreshCwIcon size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/blocks/gitlab-preview/components/IssuePreview.tsx
+++ b/src/lib/blocks/gitlab-preview/components/IssuePreview.tsx
@@ -1,0 +1,83 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { CircleDotIcon, ExternalLinkIcon, CheckCircleIcon } from "lucide-react";
+import type { GitLabIssueData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface IssuePreviewProps {
+  data: GitLabIssueData;
+}
+
+export default function IssuePreview({ data }: IssuePreviewProps) {
+  const handleClick = () => {
+    open(data.web_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" => {
+    return data.state === "opened" ? "success" : "secondary";
+  };
+
+  const getStatusIcon = () => {
+    return data.state === "opened" ? <CircleDotIcon size={14} /> : <CheckCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    return data.state === "opened" ? "Open" : "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.author.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">#{data.iid}</span>
+                <span className="text-xs text-default-400">by {data.author.username}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.description && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.description}</p>
+        )}
+
+        <div className="flex items-center gap-3 flex-wrap">
+          {data.labels.map((label) => (
+            <Chip
+              key={label}
+              size="sm"
+              variant="flat"
+            >
+              {label}
+            </Chip>
+          ))}
+          {data.user_notes_count > 0 && (
+            <span className="text-xs text-default-400">
+              {data.user_notes_count} comment{data.user_notes_count !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/gitlab-preview/components/LoadingState.tsx
+++ b/src/lib/blocks/gitlab-preview/components/LoadingState.tsx
@@ -1,0 +1,19 @@
+import { Card, CardBody, Skeleton } from "@heroui/react";
+
+export default function LoadingState() {
+  return (
+    <Card className="w-full" shadow="sm">
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-10 h-10 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-3/4 rounded" />
+            <Skeleton className="h-3 w-1/2 rounded" />
+          </div>
+        </div>
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-2/3 rounded" />
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/gitlab-preview/components/MRPreview.tsx
+++ b/src/lib/blocks/gitlab-preview/components/MRPreview.tsx
@@ -1,0 +1,78 @@
+import { Card, CardBody, Chip, Avatar } from "@heroui/react";
+import { GitPullRequestIcon, ExternalLinkIcon, GitMergeIcon, XCircleIcon } from "lucide-react";
+import type { GitLabMRData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface MRPreviewProps {
+  data: GitLabMRData;
+}
+
+export default function MRPreview({ data }: MRPreviewProps) {
+  const handleClick = () => {
+    open(data.web_url);
+  };
+
+  const getStatusColor = (): "success" | "secondary" | "danger" => {
+    if (data.state === "merged") return "secondary";
+    if (data.state === "opened") return "success";
+    return "danger";
+  };
+
+  const getStatusIcon = () => {
+    if (data.state === "merged") return <GitMergeIcon size={14} />;
+    if (data.state === "opened") return <GitPullRequestIcon size={14} />;
+    return <XCircleIcon size={14} />;
+  };
+
+  const getStatusText = () => {
+    if (data.state === "merged") return "Merged";
+    if (data.state === "opened") return "Open";
+    return "Closed";
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <Avatar src={data.author.avatar_url} size="sm" className="flex-shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm">{data.title}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-default-400">!{data.iid}</span>
+                <span className="text-xs text-default-400">by {data.author.username}</span>
+              </div>
+            </div>
+          </div>
+          <Chip
+            size="sm"
+            variant="flat"
+            color={getStatusColor()}
+            startContent={getStatusIcon()}
+            className="flex-shrink-0"
+          >
+            {getStatusText()}
+          </Chip>
+        </div>
+
+        {data.description && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.description}</p>
+        )}
+
+        {data.changes_count && (
+          <div className="flex items-center gap-4 text-sm text-default-400">
+            <span>{data.changes_count} changes</span>
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/src/lib/blocks/gitlab-preview/components/RepoPreview.tsx
+++ b/src/lib/blocks/gitlab-preview/components/RepoPreview.tsx
@@ -1,0 +1,62 @@
+import { Card, CardBody, Avatar } from "@heroui/react";
+import { StarIcon, GitForkIcon, ExternalLinkIcon } from "lucide-react";
+import type { GitLabRepoData } from "../api";
+import { open } from "@tauri-apps/plugin-shell";
+
+interface RepoPreviewProps {
+  data: GitLabRepoData;
+}
+
+export default function RepoPreview({ data }: RepoPreviewProps) {
+  const handleClick = () => {
+    open(data.web_url);
+  };
+
+  return (
+    <Card
+      className="w-full cursor-pointer hover:bg-default-100 transition-colors"
+      shadow="sm"
+      isPressable
+      onPress={handleClick}
+    >
+      <CardBody className="p-4 gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <Avatar src={data.owner.avatar_url} name={data.owner.username} size="sm" className="flex-shrink-0" />
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-sm truncate">{data.path_with_namespace}</span>
+                <ExternalLinkIcon size={14} className="text-default-400 flex-shrink-0" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {data.description && (
+          <p className="text-sm text-default-500 line-clamp-2">{data.description}</p>
+        )}
+
+        <div className="flex items-center gap-4 text-sm text-default-400">
+          <span className="flex items-center gap-1">
+            <StarIcon size={14} />
+            {formatNumber(data.star_count)}
+          </span>
+          <span className="flex items-center gap-1">
+            <GitForkIcon size={14} />
+            {formatNumber(data.forks_count)}
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1000000) {
+    return (num / 1000000).toFixed(1) + "M";
+  }
+  if (num >= 1000) {
+    return (num / 1000).toFixed(1) + "k";
+  }
+  return num.toString();
+}

--- a/src/lib/blocks/gitlab-preview/index.ts
+++ b/src/lib/blocks/gitlab-preview/index.ts
@@ -1,0 +1,5 @@
+// GitLab Preview Block - link preview for GitLab URLs
+export { default as GitLabPreviewBlockSpec } from "./spec";
+export { GITLAB_PREVIEW_BLOCK_SCHEMA, type GitLabBlockProps } from "./schema";
+export { isGitLabUrl, parseGitLabUrl } from "./url-parser";
+export type { ParsedGitLabUrl, GitLabUrlType } from "./url-parser";

--- a/src/lib/blocks/gitlab-preview/paste-handler.ts
+++ b/src/lib/blocks/gitlab-preview/paste-handler.ts
@@ -1,0 +1,51 @@
+import { linkPreviewRegistry, type LinkPreviewHandler } from "../link-preview";
+import { isGitLabUrl, parseGitLabUrl } from "./url-parser";
+import type { GitLabBlockProps } from "./schema";
+
+/**
+ * GitLab link preview handler.
+ * Converts GitLab URLs into rich preview blocks.
+ */
+export const gitlabLinkPreviewHandler: LinkPreviewHandler = {
+  id: "gitlab",
+
+  matches(url: string): boolean {
+    return isGitLabUrl(url);
+  },
+
+  createBlock(url: string): { type: string; props: Record<string, string> } | null {
+    const parsed = parseGitLabUrl(url);
+    if (!parsed) {
+      return null;
+    }
+
+    const props: Partial<GitLabBlockProps> = {
+      url,
+      urlType: parsed.type,
+      projectPath: parsed.projectPath,
+    };
+
+    if (parsed.type === "mr" && parsed.mrNumber !== undefined) {
+      props.mrNumber = parsed.mrNumber.toString();
+    }
+
+    if (parsed.type === "issue" && parsed.issueNumber !== undefined) {
+      props.issueNumber = parsed.issueNumber.toString();
+    }
+
+    if (parsed.type === "code") {
+      if (parsed.branch) props.branch = parsed.branch;
+      if (parsed.filePath) props.filePath = parsed.filePath;
+      if (parsed.lineStart !== undefined) props.lineStart = parsed.lineStart.toString();
+      if (parsed.lineEnd !== undefined) props.lineEnd = parsed.lineEnd.toString();
+    }
+
+    return {
+      type: "gitlabPreview",
+      props: props as Record<string, string>,
+    };
+  },
+};
+
+// Register the GitLab handler
+linkPreviewRegistry.register(gitlabLinkPreviewHandler);

--- a/src/lib/blocks/gitlab-preview/schema.ts
+++ b/src/lib/blocks/gitlab-preview/schema.ts
@@ -1,0 +1,31 @@
+export const GITLAB_PREVIEW_BLOCK_SCHEMA = {
+  type: "gitlabPreview",
+  propSchema: {
+    url: { default: "" },
+    urlType: { default: "" }, // "repo" | "mr" | "issue" | "code"
+    projectPath: { default: "" }, // GitLab uses nested paths: group/subgroup/project
+    mrNumber: { default: "" },
+    issueNumber: { default: "" },
+    branch: { default: "" },
+    filePath: { default: "" },
+    lineStart: { default: "" },
+    lineEnd: { default: "" },
+    cachedData: { default: "{}" },
+    cachedAt: { default: "" },
+  },
+  content: "none",
+} as const;
+
+export type GitLabBlockProps = {
+  url: string;
+  urlType: string;
+  projectPath: string;
+  mrNumber: string;
+  issueNumber: string;
+  branch: string;
+  filePath: string;
+  lineStart: string;
+  lineEnd: string;
+  cachedData: string;
+  cachedAt: string;
+};

--- a/src/lib/blocks/gitlab-preview/spec.tsx
+++ b/src/lib/blocks/gitlab-preview/spec.tsx
@@ -1,0 +1,23 @@
+// @ts-ignore
+import { createReactBlockSpec } from "@blocknote/react";
+
+import GitLabPreview from "./components/GitLabPreview";
+import { GITLAB_PREVIEW_BLOCK_SCHEMA, GitLabBlockProps } from "./schema";
+
+export default createReactBlockSpec(GITLAB_PREVIEW_BLOCK_SCHEMA, {
+  // @ts-ignore
+  render: ({ block, editor }) => {
+    const updateProps = (updates: Partial<GitLabBlockProps>) => {
+      editor.updateBlock(block, {
+        // @ts-ignore
+        props: { ...block.props, ...updates },
+      });
+    };
+
+    return (
+      <div contentEditable={false} className="w-full">
+        <GitLabPreview props={block.props} updateProps={updateProps} />
+      </div>
+    );
+  },
+});

--- a/src/lib/blocks/gitlab-preview/url-parser.ts
+++ b/src/lib/blocks/gitlab-preview/url-parser.ts
@@ -1,0 +1,88 @@
+export type GitLabUrlType = "repo" | "mr" | "issue" | "code";
+
+export interface ParsedGitLabUrl {
+  type: GitLabUrlType;
+  projectPath: string; // Can be nested: group/subgroup/project
+  mrNumber?: number;
+  issueNumber?: number;
+  branch?: string;
+  filePath?: string;
+  lineStart?: number;
+  lineEnd?: number;
+}
+
+const GITLAB_URL_REGEX = /^https?:\/\/(www\.)?gitlab\.com\/(.+?)(?:\/-\/(.*))?$/;
+
+export function isGitLabUrl(text: string): boolean {
+  return GITLAB_URL_REGEX.test(text.trim());
+}
+
+export function parseGitLabUrl(url: string): ParsedGitLabUrl | null {
+  const trimmedUrl = url.trim();
+  const match = trimmedUrl.match(GITLAB_URL_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  let projectPath = match[2];
+  const rest = match[3] || "";
+
+  // Remove trailing slash from project path
+  projectPath = projectPath.replace(/\/$/, "");
+
+  // If rest is empty, it's a repo URL
+  if (!rest) {
+    return {
+      type: "repo",
+      projectPath,
+    };
+  }
+
+  // Check for MR URL: merge_requests/{number}
+  const mrMatch = rest.match(/^merge_requests\/(\d+)/);
+  if (mrMatch) {
+    return {
+      type: "mr",
+      projectPath,
+      mrNumber: parseInt(mrMatch[1], 10),
+    };
+  }
+
+  // Check for issue URL: issues/{number}
+  const issueMatch = rest.match(/^issues\/(\d+)/);
+  if (issueMatch) {
+    return {
+      type: "issue",
+      projectPath,
+      issueNumber: parseInt(issueMatch[1], 10),
+    };
+  }
+
+  // Check for code URL: blob/{branch}/{path}#L{start}-{end}
+  // GitLab uses #L10-20 format (not #L10-L20)
+  const codeMatch = rest.match(/^blob\/([^/]+)\/(.+?)(?:#L(\d+)(?:-(\d+))?)?$/);
+  if (codeMatch) {
+    const result: ParsedGitLabUrl = {
+      type: "code",
+      projectPath,
+      branch: codeMatch[1],
+      filePath: codeMatch[2],
+    };
+
+    if (codeMatch[3]) {
+      result.lineStart = parseInt(codeMatch[3], 10);
+    }
+    if (codeMatch[4]) {
+      result.lineEnd = parseInt(codeMatch[4], 10);
+    }
+
+    return result;
+  }
+
+  // Default to repo for other paths
+  return {
+    type: "repo",
+    projectPath,
+  };
+}

--- a/src/lib/blocks/link-preview/index.ts
+++ b/src/lib/blocks/link-preview/index.ts
@@ -1,0 +1,2 @@
+export { linkPreviewRegistry, type LinkPreviewHandler } from "./registry";
+export { linkPreviewPasteHandler } from "./paste-handler";

--- a/src/lib/blocks/link-preview/paste-handler.ts
+++ b/src/lib/blocks/link-preview/paste-handler.ts
@@ -1,0 +1,79 @@
+import { linkPreviewRegistry } from "./registry";
+
+interface PasteHandlerContext {
+  event: ClipboardEvent;
+  editor: any; // BlockNoteEditor
+  defaultPasteHandler: (context?: {
+    prioritizeMarkdownOverHTML?: boolean;
+    plainTextAsMarkdown?: boolean;
+  }) => boolean | undefined;
+}
+
+/**
+ * Normalize pasted text by stripping common URL wrappers.
+ */
+function normalizeUrl(text: string): string {
+  let url = text.trim();
+
+  // Strip angle brackets: <https://...>
+  if (url.startsWith("<") && url.endsWith(">")) {
+    url = url.slice(1, -1);
+  }
+
+  return url;
+}
+
+/**
+ * Generic paste handler for link previews.
+ * Checks the link preview registry for handlers that match the pasted URL.
+ *
+ * - On empty paragraph + matching URL → converts to preview block
+ * - Otherwise → falls through to default paste handler
+ */
+export function linkPreviewPasteHandler({
+  event,
+  editor,
+  defaultPasteHandler,
+}: PasteHandlerContext): boolean | undefined {
+  const rawText = event.clipboardData?.getData("text/plain");
+  if (!rawText) {
+    return defaultPasteHandler();
+  }
+
+  const url = normalizeUrl(rawText);
+
+  // Check if any handler matches this URL
+  const handler = linkPreviewRegistry.findHandler(url);
+  if (!handler) {
+    return defaultPasteHandler();
+  }
+
+  // Check if current block is empty
+  const currentBlock = editor.getTextCursorPosition()?.block;
+  if (!currentBlock) {
+    return defaultPasteHandler();
+  }
+
+  // Only convert on blank line - check if block is empty paragraph
+  const isEmptyParagraph =
+    currentBlock.type === "paragraph" &&
+    (!currentBlock.content || currentBlock.content.length === 0);
+
+  if (!isEmptyParagraph) {
+    return defaultPasteHandler();
+  }
+
+  // Create the block
+  const block = handler.createBlock(url);
+  if (!block) {
+    return defaultPasteHandler();
+  }
+
+  // Replace the empty paragraph with the preview block
+  editor.updateBlock(currentBlock, {
+    type: block.type,
+    props: block.props,
+  });
+
+  return true;
+}

--- a/src/lib/blocks/link-preview/registry.ts
+++ b/src/lib/blocks/link-preview/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Registry for link preview handlers.
+ * Allows registering URL matchers that convert pasted URLs into rich preview blocks.
+ */
+
+export interface LinkPreviewHandler {
+  /** Unique identifier for this handler */
+  id: string;
+
+  /** Check if this handler can process the given URL */
+  matches: (url: string) => boolean;
+
+  /** Convert the URL into block props. Returns the block type and props. */
+  createBlock: (url: string) => { type: string; props: Record<string, string> } | null;
+}
+
+class LinkPreviewRegistry {
+  private handlers: LinkPreviewHandler[] = [];
+
+  /**
+   * Register a new link preview handler.
+   * Handlers are checked in order of registration.
+   */
+  register(handler: LinkPreviewHandler): void {
+    // Avoid duplicate registrations
+    if (this.handlers.some((h) => h.id === handler.id)) {
+      return;
+    }
+    this.handlers.push(handler);
+  }
+
+  /**
+   * Find a handler that matches the given URL.
+   * Returns the first matching handler, or null if none match.
+   */
+  findHandler(url: string): LinkPreviewHandler | null {
+    for (const handler of this.handlers) {
+      if (handler.matches(url)) {
+        return handler;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Try to create a block from a URL.
+   * Returns null if no handler matches or if the handler fails to create a block.
+   */
+  createBlock(url: string): { type: string; props: Record<string, string> } | null {
+    const handler = this.findHandler(url);
+    if (!handler) {
+      return null;
+    }
+    return handler.createBlock(url);
+  }
+
+  /**
+   * Get all registered handlers (for debugging/inspection)
+   */
+  getHandlers(): readonly LinkPreviewHandler[] {
+    return this.handlers;
+  }
+}
+
+// Singleton instance
+export const linkPreviewRegistry = new LinkPreviewRegistry();

--- a/src/lib/blocks/shared/language-detection.ts
+++ b/src/lib/blocks/shared/language-detection.ts
@@ -1,0 +1,48 @@
+/**
+ * Map file extensions to language identifiers for syntax highlighting.
+ */
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  js: "javascript",
+  jsx: "jsx",
+  ts: "typescript",
+  tsx: "tsx",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  cpp: "cpp",
+  h: "c",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  json: "json",
+  xml: "xml",
+  html: "html",
+  css: "css",
+  scss: "scss",
+  sass: "sass",
+  less: "less",
+  md: "markdown",
+  sql: "sql",
+  graphql: "graphql",
+  dockerfile: "dockerfile",
+  toml: "toml",
+  ini: "ini",
+  conf: "ini",
+};
+
+/**
+ * Get the language identifier for syntax highlighting based on file extension.
+ */
+export function extensionToLanguage(ext: string): string {
+  return EXTENSION_TO_LANGUAGE[ext.toLowerCase()] || "text";
+}


### PR DESCRIPTION
## Change Summary
Add rich preview blocks that convert pasted URLs into interactive cards displaying metadata from GitHub, GitLab, and Codeberg.

## Motivation and details
Blocks are created only via paste handler for a cleaner UX (not accessible through slash menu). Supports rendering repositories, issues, PRs, and code files with syntax highlighting. API responses are cached for 1 hour to avoid redundant requests. All identified code issues from review have been fixed: missing issue handling, debug logs removed, duplicated code consolidated, memory leaks addressed, and dead code removed.

## Tasks
- [x] Code review issues fixed
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle