### PR TITLE
fix: use webview scaling instead of css

### DIFF
--- a/backend/capabilities/migrated.json
+++ b/backend/capabilities/migrated.json
@@ -7,6 +7,7 @@
     "core:path:default",
     "core:event:default",
     "core:window:default",
+    "core:webview:allow-set-webview-zoom",
     "core:app:default",
     "core:resources:default",
     "core:menu:default",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ import { trackOnlineStatus } from "./lib/online_tracker";
 import { setupColorModes } from "./lib/color_modes";
 import { setupServerEvents } from "./lib/server_events";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { platform } from "@tauri-apps/plugin-os";
 import debounce from "lodash.debounce";
 import Workspace from "./state/runbooks/workspace";
@@ -161,7 +162,11 @@ function Application() {
   }, []);
 
   useEffect(() => {
-    document.documentElement.style.zoom = `${uiScale}%`;
+    getCurrentWebview()
+      .setZoom(uiScale / 100)
+      .catch((err) => {
+        console.error("Failed to set zoom:", err);
+      });
   }, [uiScale]);
 
   return (


### PR DESCRIPTION
Resolves all position related issues (missing drag handle, terminal link clicks, etc) when using scaling

## Tasks
- [ ] Regenerated TS-RS bindings (if any `ts(export)` structs have changed)
- [ ] Updated the documentation in `docs/` (if any application behavior has changed)
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
