### PR TITLE
Remove macOS x86_64 builds from publish pipeline

### DIFF
--- a/.github/workflows/tauri-edge.yaml
+++ b/.github/workflows/tauri-edge.yaml
@@ -156,8 +156,6 @@ jobs:
           platform_suffix=""
           if [[ "${{ matrix.args }}" == *"aarch64-apple-darwin"* ]]; then
             platform_suffix="-aarch64"
-          elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
-            platform_suffix="-x86_64"
           fi
 
           # Rename files and upload to GitHub release
@@ -243,7 +241,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,aarch64-apple-darwin,x86_64-apple-darwin
+          targets: aarch64-apple-darwin
 
       - name: Install CEF tauri-cli
         run: cargo install --git https://github.com/tauri-apps/tauri --branch feat/cef tauri-cli

--- a/.github/workflows/tauri-release.yaml
+++ b/.github/workflows/tauri-release.yaml
@@ -77,8 +77,6 @@ jobs:
         include:
           - platform: "macos-latest" # for Arm based macs (M1 and above).
             args: "--target aarch64-apple-darwin"
-          - platform: "macos-15-intel"
-            args: "--target x86_64-apple-darwin"
           - platform: "depot-ubuntu-22.04-4"
             args: ""
 
@@ -110,7 +108,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable # Set this to dtolnay/rust-toolchain@nightly
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ (matrix.platform == 'macos-latest' || matrix.platform == 'macos-15-intel') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -155,8 +153,6 @@ jobs:
           platform_suffix=""
           if [[ "${{ matrix.args }}" == *"aarch64-apple-darwin"* ]]; then
             platform_suffix="-aarch64"
-          elif [[ "${{ matrix.args }}" == *"x86_64-apple-darwin"* ]]; then
-            platform_suffix="-x86_64"
           fi
 
           # Rename files and upload to GitHub release


### PR DESCRIPTION
## Change Summary
Remove all Intel Mac (x86_64) build targets from CI/CD workflows. Only Apple Silicon (aarch64) builds are now created for macOS.

## Motivation and details
Simplifies the publish pipeline by eliminating the separate Intel Mac build matrix entry and associated configuration. Apple Silicon is now the primary target platform. Intel Mac users can still run the app via Rosetta 2 translation layer.

## Tasks
- [x] No TS-RS bindings affected
- [x] No documentation changes needed (this is an internal CI change)