### PR TITLE
fix: SSH connection sometimes doesn't read until EOF

### DIFF
--- a/crates/atuin-desktop-runtime/src/ssh/session.rs
+++ b/crates/atuin-desktop-runtime/src/ssh/session.rs
@@ -1452,9 +1452,12 @@ impl Session {
                                     }
                                 }
                             }
+                            // ExitStatus signals the command's exit code but does NOT
+                            // guarantee all Data messages have been delivered (RFC 4254
+                            // §6.10). Only Eof guarantees no more data will follow.
+                            // Continue reading until Eof or Close.
                             ChannelMsg::ExitStatus { .. } => {
-                                tracing::trace!("Handling SSH ExitStatus message");
-                                break;
+                                tracing::trace!("Handling SSH ExitStatus message (continuing to read)");
                             }
                             ChannelMsg::Eof => {
                                 tracing::trace!("Handling SSH EOF message");


### PR DESCRIPTION
## Don't stop reading from SSH session until EOF

Previously, we `break`ed when receiving the `ExitStatus` message, but per RFC 4254 §6.10, this doesn't mean all data has arrived. We now log and continue reading data until we get the actual EOF.

It's not clear to me if this affects #373 at all; I'm not able to reproduce that exact issue, but I was able to reproduce a somewhat similar one with script blocks that this does fix.

## Call `exec_finished` when SSH command fails

This is just a failure mode that we didn't handle correctly - if the SSH command failed to run, we never called `exec_finished`.